### PR TITLE
fix: add make and conan profile detect to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,63 @@
 FROM ubuntu:24.04 AS builder
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake ninja-build g++ git ca-certificates libssl-dev \
+    cmake \
+    ninja-build \
+    make \
+    g++ \
+    git \
+    ca-certificates \
+    libssl-dev \
+    python3 \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --break-system-packages conan && conan profile detect
+
 WORKDIR /src
+
+# Copy Conan files first for dependency caching.
+COPY conanfile.py ./
+COPY conan/ conan/
+RUN conan install . \
+    --output-folder=build \
+    --profile=conan/profiles/default \
+    --build=missing
+
+# Copy CMake configuration so FetchContent (nats.c) can be cached separately.
 COPY CMakeLists.txt ./
 COPY cmake/ cmake/
+
+# Copy source tree.
 COPY include/ include/
 COPY src/ src/
 COPY test/ test/
+
 RUN cmake -B build -G Ninja \
+    -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DProjectNestor_BUILD_TESTING=OFF \
     -DProjectNestor_ENABLE_CLANG_TIDY=OFF \
     -DProjectNestor_ENABLE_CPPCHECK=OFF \
     && cmake --build build --target ProjectNestor_server
 
+# ── Runtime image ─────────────────────────────────────────────────────────────
 FROM ubuntu:24.04
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libssl3 wget \
+    libssl3 \
+    wget \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /src/build/ProjectNestor_server /usr/local/bin/
+
+COPY --from=builder /src/build/ProjectNestor_server /usr/local/bin/ProjectNestor_server
+
 EXPOSE 8081
+
 ENV NESTOR_PORT=8081
 ENV NATS_URL=nats://localhost:4222
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -qO- http://localhost:${NESTOR_PORT}/v1/health || exit 1
 
 RUN useradd -r -s /usr/sbin/nologin nestor
 USER nestor


### PR DESCRIPTION
## Summary

- Added `make` to builder image dependencies (required by gtest's Unix Makefiles recipe)
- Added `conan profile detect` after installing Conan (ensures default profile exists before `conan install`)
- Reorganized Dockerfile to include Conan dependency stage and improve Docker layer caching
- Added HEALTHCHECK instruction to runtime image
- Fixed COPY path for ProjectNestor_server binary in runtime image

## Test plan

- [ ] Docker build succeeds
- [ ] Built image starts and responds to health checks
- [ ] Application serves requests on port 8081

Generated with Claude Code