### PR TITLE
feat(nats): publish hi.logs.nestor.* structured log events

### DIFF
--- a/include/projectnestor/nats_client.hpp
+++ b/include/projectnestor/nats_client.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <string>
 
+#include "nlohmann/json.hpp"
+
 namespace projectnestor {
 
 class NatsClient {
@@ -18,6 +20,11 @@ class NatsClient {
 
   // Publish payload to subject. Returns false if not connected or publish fails.
   bool publish(const std::string& subject, const std::string& payload);
+
+  // Publish a structured log event to hi.logs.nestor.* (ADR-005).
+  // Fire-and-forget: never fails the caller if NATS is unavailable.
+  void publish_log(const std::string& subject, const std::string& level,
+                   const std::string& message, const nlohmann::json& metadata);
 
  private:
   std::string url_;

--- a/include/projectnestor/nats_client.hpp
+++ b/include/projectnestor/nats_client.hpp
@@ -23,8 +23,8 @@ class NatsClient {
 
   // Publish a structured log event to hi.logs.nestor.* (ADR-005).
   // Fire-and-forget: never fails the caller if NATS is unavailable.
-  void publish_log(const std::string& subject, const std::string& level,
-                   const std::string& message, const nlohmann::json& metadata);
+  void publish_log(const std::string& subject, const std::string& level, const std::string& message,
+                   const nlohmann::json& metadata);
 
  private:
   std::string url_;

--- a/include/projectnestor/store.hpp
+++ b/include/projectnestor/store.hpp
@@ -17,6 +17,10 @@ class Store {
   json get_stats() const;
   json submit_research(const json& body);
 
+  // Mark a research task as completed.  Returns the updated item, or a JSON
+  // object with {"error": "not_found"} if the id is unknown.
+  json complete_research(const std::string& id);
+
  private:
   mutable std::mutex mutex_;
   std::atomic<int> active_{0};

--- a/src/nats_client.cpp
+++ b/src/nats_client.cpp
@@ -114,16 +114,12 @@ void NatsClient::publish_log(const std::string& subject, const std::string& leve
     return;  // Graceful degradation — NATS unavailable.
   }
 
-  const double timestamp = std::chrono::duration<double>(
-                               std::chrono::system_clock::now().time_since_epoch())
-                               .count();
+  const double timestamp =
+      std::chrono::duration<double>(std::chrono::system_clock::now().time_since_epoch()).count();
 
   const nlohmann::json payload = {
-      {"timestamp", timestamp},
-      {"service", "nestor"},
-      {"level", level},
-      {"message", message},
-      {"metadata", metadata},
+      {"timestamp", timestamp}, {"service", "nestor"},  {"level", level},
+      {"message", message},     {"metadata", metadata},
   };
 
   const std::string payload_str = payload.dump();

--- a/src/nats_client.cpp
+++ b/src/nats_client.cpp
@@ -3,9 +3,11 @@
 
 #include "projectnestor/nats_client.hpp"
 
+#include <chrono>
 #include <iostream>
 
 #include "nats.h"
+#include "nlohmann/json.hpp"
 
 namespace projectnestor {
 
@@ -104,6 +106,32 @@ bool NatsClient::publish(const std::string& subject, const std::string& payload)
     return false;
   }
   return true;
+}
+
+void NatsClient::publish_log(const std::string& subject, const std::string& level,
+                             const std::string& message, const nlohmann::json& metadata) {
+  if (!connected_) {
+    return;  // Graceful degradation — NATS unavailable.
+  }
+
+  const double timestamp = std::chrono::duration<double>(
+                               std::chrono::system_clock::now().time_since_epoch())
+                               .count();
+
+  const nlohmann::json payload = {
+      {"timestamp", timestamp},
+      {"service", "nestor"},
+      {"level", level},
+      {"message", message},
+      {"metadata", metadata},
+  };
+
+  const std::string payload_str = payload.dump();
+
+  // Use core NATS publish (non-JetStream) for fire-and-forget log delivery.
+  natsConnection_PublishString(reinterpret_cast<natsConnection*>(conn_), subject.c_str(),
+                               payload_str.c_str());
+  // Return value intentionally ignored — log publish failures are non-fatal.
 }
 
 }  // namespace projectnestor

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -37,6 +37,7 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
 
     const json result = sp->submit_research(body);
     const std::string id = result["id"].get<std::string>();
+    const std::string topic = body.value("idea", body.value("topic", ""));
 
     // Publish to hi.research.<id> — graceful degradation if NATS unavailable.
     const std::string subject = "hi.research." + id;
@@ -45,9 +46,37 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
     payload["status"] = "pending";
     np->publish(subject, payload.dump());
 
+    // Structured log: hi.logs.nestor.research_submitted (ADR-005).
+    np->publish_log("hi.logs.nestor.research_submitted", "info",
+                    "Research submitted: topic=" + topic,
+                    json{{"research_id", id}, {"topic", topic}});
+
     res.status = 202;
     res.set_content(result.dump(), "application/json");
   });
+
+  // ── Complete Research ─────────────────────────────────────────────────────
+
+  server.Post("/v1/research/:id/complete",
+              [sp, np](const httplib::Request& req, httplib::Response& res) {
+                const std::string id = req.path_params.at("id");
+                const json updated = sp->complete_research(id);
+
+                if (updated.contains("error")) {
+                  res.status = 404;
+                  res.set_content(updated.dump(), "application/json");
+                  return;
+                }
+
+                const std::string topic = updated.value("idea", updated.value("topic", ""));
+
+                // Structured log: hi.logs.nestor.research_completed (ADR-005).
+                np->publish_log("hi.logs.nestor.research_completed", "info",
+                                "Research completed: topic=" + topic,
+                                json{{"research_id", id}, {"topic", topic}});
+
+                res.set_content(updated.dump(), "application/json");
+              });
 }
 
 }  // namespace projectnestor

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -80,4 +80,19 @@ json Store::submit_research(const json& body) {
   return json{{"id", id}, {"status", "pending"}};
 }
 
+json Store::complete_research(const std::string& id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = research_items_.find(id);
+  if (it == research_items_.end()) {
+    return json{{"error", "not_found"}};
+  }
+
+  it->second["status"] = "completed";
+  it->second["completed_at"] = now_iso8601();
+  --pending_;
+  ++completed_;
+
+  return it->second;
+}
+
 }  // namespace projectnestor

--- a/test/src/test_nats_client.cpp
+++ b/test/src/test_nats_client.cpp
@@ -48,4 +48,12 @@ TEST(NatsClientTest, DoubleCloseIsSafe) {
   EXPECT_FALSE(client.is_connected());
 }
 
+TEST(NatsClientTest, PublishLogWhenNotConnectedIsNoOp) {
+  // publish_log must not throw or crash when NATS is unavailable.
+  NatsClient client("nats://127.0.0.1:1");
+  EXPECT_NO_THROW(client.publish_log("hi.logs.nestor.research_submitted", "info",
+                                     "Research submitted: topic=test",
+                                     nlohmann::json{{"research_id", "abc"}, {"topic", "test"}}));
+}
+
 }  // namespace projectnestor::test

--- a/test/src/test_routes.cpp
+++ b/test/src/test_routes.cpp
@@ -101,7 +101,8 @@ TEST_F(RoutesTest, CompleteResearchReturns200) {
   const std::string id = json::parse(submit_res->body)["id"].get<std::string>();
 
   // Complete it.
-  const auto complete_res = client_->Post("/v1/research/" + id + "/complete", "", "application/json");
+  const auto complete_res =
+      client_->Post("/v1/research/" + id + "/complete", "", "application/json");
   ASSERT_TRUE(complete_res);
   EXPECT_EQ(complete_res->status, 200);
   const auto body = json::parse(complete_res->body);

--- a/test/src/test_routes.cpp
+++ b/test/src/test_routes.cpp
@@ -92,4 +92,44 @@ TEST_F(RoutesTest, StatsReflectsSubmission) {
   EXPECT_EQ(body["pending"], 1);
 }
 
+TEST_F(RoutesTest, CompleteResearchReturns200) {
+  // Submit first to get a valid id.
+  const std::string payload = R"({"idea":"test idea","context":"ctx"})";
+  const auto submit_res = client_->Post("/v1/research", payload, "application/json");
+  ASSERT_TRUE(submit_res);
+  ASSERT_EQ(submit_res->status, 202);
+  const std::string id = json::parse(submit_res->body)["id"].get<std::string>();
+
+  // Complete it.
+  const auto complete_res = client_->Post("/v1/research/" + id + "/complete", "", "application/json");
+  ASSERT_TRUE(complete_res);
+  EXPECT_EQ(complete_res->status, 200);
+  const auto body = json::parse(complete_res->body);
+  EXPECT_EQ(body["status"], "completed");
+  EXPECT_EQ(body["id"], id);
+}
+
+TEST_F(RoutesTest, CompleteResearchUnknownIdReturns404) {
+  const auto res = client_->Post("/v1/research/nonexistent-id/complete", "", "application/json");
+  ASSERT_TRUE(res);
+  EXPECT_EQ(res->status, 404);
+  const auto body = json::parse(res->body);
+  EXPECT_EQ(body["error"], "not_found");
+}
+
+TEST_F(RoutesTest, StatsReflectsCompletion) {
+  const std::string payload = R"({"idea":"test","context":"ctx"})";
+  const auto submit_res = client_->Post("/v1/research", payload, "application/json");
+  ASSERT_TRUE(submit_res);
+  const std::string id = json::parse(submit_res->body)["id"].get<std::string>();
+
+  client_->Post("/v1/research/" + id + "/complete", "", "application/json");
+
+  const auto res = client_->Get("/v1/research/stats");
+  ASSERT_TRUE(res);
+  const auto body = json::parse(res->body);
+  EXPECT_EQ(body["pending"], 0);
+  EXPECT_EQ(body["completed"], 1);
+}
+
 }  // namespace projectnestor::test

--- a/test/src/test_store.cpp
+++ b/test/src/test_store.cpp
@@ -80,4 +80,25 @@ TEST(StoreTest, SubmitResearchMultipleItems) {
   EXPECT_EQ(store.get_stats()["pending"], 3);
 }
 
+TEST(StoreTest, CompleteResearchTransitionsStatus) {
+  Store store;
+  const json submit_result = store.submit_research({{"idea", "test idea"}});
+  const std::string id = submit_result["id"].get<std::string>();
+
+  const json completed = store.complete_research(id);
+  EXPECT_EQ(completed["id"], id);
+  EXPECT_EQ(completed["status"], "completed");
+  EXPECT_TRUE(completed.contains("completed_at"));
+
+  const json stats = store.get_stats();
+  EXPECT_EQ(stats["pending"], 0);
+  EXPECT_EQ(stats["completed"], 1);
+}
+
+TEST(StoreTest, CompleteResearchUnknownIdReturnsError) {
+  Store store;
+  const json result = store.complete_research("nonexistent-id");
+  EXPECT_EQ(result["error"], "not_found");
+}
+
 }  // namespace projectnestor::test


### PR DESCRIPTION
Implements HomericIntelligence/Odysseus#76

Adds NATS publish calls on key Nestor operations:
- `hi.logs.nestor.research_submitted` — on new research request received
- `hi.logs.nestor.research_completed` — on research task completed

Payload format:
```json
{"timestamp": 1712160000.123, "service": "nestor", "level": "info", "message": "...", "metadata": {...}}
```

Publish is fire-and-forget — NATS failures do not fail request handling.

## Changes

**`NatsClient::publish_log(subject, level, message, metadata)`** (new method)
- Builds ADR-005 compliant JSON payload with `timestamp` (Unix epoch float), `service`, `level`, `message`, `metadata`
- Uses `natsConnection_PublishString` (core NATS, not JetStream) for fire-and-forget delivery
- Returns early silently if `connected_` is false — graceful degradation

**`Store::complete_research(id)`** (new method)
- Transitions a research item to `"completed"` status, sets `completed_at`
- Atomically decrements `pending_`, increments `completed_`
- Returns `{"error": "not_found"}` for unknown IDs

**`POST /v1/research`** (updated)
- Now calls `publish_log("hi.logs.nestor.research_submitted", ...)` after successful submit

**`POST /v1/research/:id/complete`** (new route)
- Calls `complete_research`, returns 404 for unknown IDs
- Calls `publish_log("hi.logs.nestor.research_completed", ...)` on success

## Tests added
- `NatsClientTest::PublishLogWhenNotConnectedIsNoOp`
- `StoreTest::CompleteResearchTransitionsStatus`
- `StoreTest::CompleteResearchUnknownIdReturnsError`
- `RoutesTest::CompleteResearchReturns200`
- `RoutesTest::CompleteResearchUnknownIdReturns404`
- `RoutesTest::StatsReflectsCompletion`