### PR TITLE
fix(docs): replace archived mozilla/inclusion link with current URL

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -104,6 +104,6 @@ For answers to common questions about this code of conduct, see the FAQ at
 
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
-[mozilla coc]: https://github.com/mozilla/inclusion
+[mozilla coc]: https://www.mozilla.org/en-US/about/governance/policies/participation/
 [faq]: https://www.contributor-covenant.org/faq/
 [translations]: https://www.contributor-covenant.org/translations/


### PR DESCRIPTION
## Summary

- Updates the dead `[mozilla coc]` link in `CODE_OF_CONDUCT.md` from the archived `github.com/mozilla/inclusion` repo to the current Mozilla Community Participation Guidelines page at `mozilla.org`

## Changes

- `CODE_OF_CONDUCT.md` line 107: replaced `https://github.com/mozilla/inclusion` with `https://www.mozilla.org/en-US/about/governance/policies/participation/`

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)