### PR TITLE
refactor(routes): extract duplicated topic-field fallback into lambda

### DIFF
--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -32,33 +32,34 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
     res.set_content(sp->get_stats().dump(), "application/json");
   });
 
-  server.Post("/v1/research", [sp, np, extract_topic](const httplib::Request& req, httplib::Response& res) {
-    const auto body = json::parse(req.body, nullptr, false);
-    if (body.is_discarded()) {
-      res.status = 400;
-      res.set_content(json{{"detail", "Invalid JSON"}}.dump(), "application/json");
-      return;
-    }
+  server.Post("/v1/research",
+              [sp, np, extract_topic](const httplib::Request& req, httplib::Response& res) {
+                const auto body = json::parse(req.body, nullptr, false);
+                if (body.is_discarded()) {
+                  res.status = 400;
+                  res.set_content(json{{"detail", "Invalid JSON"}}.dump(), "application/json");
+                  return;
+                }
 
-    const json result = sp->submit_research(body);
-    const std::string id = result["id"].get<std::string>();
-    const std::string topic = extract_topic(body);
+                const json result = sp->submit_research(body);
+                const std::string id = result["id"].get<std::string>();
+                const std::string topic = extract_topic(body);
 
-    // Publish to hi.research.<id> — graceful degradation if NATS unavailable.
-    const std::string subject = "hi.research." + id;
-    json payload = body;
-    payload["id"] = id;
-    payload["status"] = "pending";
-    np->publish(subject, payload.dump());
+                // Publish to hi.research.<id> — graceful degradation if NATS unavailable.
+                const std::string subject = "hi.research." + id;
+                json payload = body;
+                payload["id"] = id;
+                payload["status"] = "pending";
+                np->publish(subject, payload.dump());
 
-    // Structured log: hi.logs.nestor.research_submitted (ADR-005).
-    np->publish_log("hi.logs.nestor.research_submitted", "info",
-                    "Research submitted: topic=" + topic,
-                    json{{"research_id", id}, {"topic", topic}});
+                // Structured log: hi.logs.nestor.research_submitted (ADR-005).
+                np->publish_log("hi.logs.nestor.research_submitted", "info",
+                                "Research submitted: topic=" + topic,
+                                json{{"research_id", id}, {"topic", topic}});
 
-    res.status = 202;
-    res.set_content(result.dump(), "application/json");
-  });
+                res.status = 202;
+                res.set_content(result.dump(), "application/json");
+              });
 
   // ── Complete Research ─────────────────────────────────────────────────────
 

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -32,7 +32,7 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
     res.set_content(sp->get_stats().dump(), "application/json");
   });
 
-  server.Post("/v1/research", [sp, np](const httplib::Request& req, httplib::Response& res) {
+  server.Post("/v1/research", [sp, np, extract_topic](const httplib::Request& req, httplib::Response& res) {
     const auto body = json::parse(req.body, nullptr, false);
     if (body.is_discarded()) {
       res.status = 400;
@@ -63,7 +63,7 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
   // ── Complete Research ─────────────────────────────────────────────────────
 
   server.Post("/v1/research/:id/complete",
-              [sp, np](const httplib::Request& req, httplib::Response& res) {
+              [sp, np, extract_topic](const httplib::Request& req, httplib::Response& res) {
                 const std::string id = req.path_params.at("id");
                 const json updated = sp->complete_research(id);
 

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -15,6 +15,11 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
   Store* sp = &store;
   NatsClient* np = &nats;
 
+  // Helper: extract topic field, falling back from "idea" to "topic".
+  auto extract_topic = [](const json& j) -> std::string {
+    return j.value("idea", j.value("topic", ""));
+  };
+
   // ── Health ────────────────────────────────────────────────────────────────
 
   server.Get("/v1/health", [](const httplib::Request& /*req*/, httplib::Response& res) {
@@ -37,7 +42,7 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
 
     const json result = sp->submit_research(body);
     const std::string id = result["id"].get<std::string>();
-    const std::string topic = body.value("idea", body.value("topic", ""));
+    const std::string topic = extract_topic(body);
 
     // Publish to hi.research.<id> — graceful degradation if NATS unavailable.
     const std::string subject = "hi.research." + id;
@@ -68,7 +73,7 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
                   return;
                 }
 
-                const std::string topic = updated.value("idea", updated.value("topic", ""));
+                const std::string topic = extract_topic(updated);
 
                 // Structured log: hi.logs.nestor.research_completed (ADR-005).
                 np->publish_log("hi.logs.nestor.research_completed", "info",


### PR DESCRIPTION
## Summary

- Extracts the repeated two-field fallback pattern `body.value("idea", body.value("topic", ""))` from two call sites in `register_routes()` into a local lambda `extract_topic`
- Both the `/v1/research` POST handler and the `/v1/research/:id/complete` POST handler now call `extract_topic(body)` / `extract_topic(updated)` instead

## Changes

- `src/routes.cpp`: add `extract_topic` lambda near top of `register_routes()`; replace two inline usages

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)