### PR TITLE
refactor(ci): deduplicate conan setup via composite action

### DIFF
--- a/.github/actions/conan-install/action.yml
+++ b/.github/actions/conan-install/action.yml
@@ -1,0 +1,29 @@
+name: Conan Install
+description: >
+  Installs Conan, detects the default profile, and runs conan install for
+  the requested build type. Deduplicates the conan setup sequence that was
+  previously copy-pasted across multiple CI workflows.
+
+inputs:
+  build-type:
+    description: 'Conan build type (Debug or Release)'
+    required: true
+    default: Release
+
+runs:
+  using: composite
+  steps:
+    - name: Install Conan
+      shell: bash
+      run: pip install conan
+
+    - name: Detect Conan profile
+      shell: bash
+      run: conan profile detect --force
+
+    - name: Install Conan dependencies
+      shell: bash
+      run: |
+        conan install . --build=missing \
+          -s build_type="${{ inputs.build-type }}" \
+          --output-folder "build/$(echo '${{ inputs.build-type }}' | tr '[:upper:]' '[:lower:]')"

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -28,12 +28,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ninja-build clang clang-tidy
-          pip install conan
-          conan profile detect --force
-      - name: Install Conan dependencies
-        run: |
-          conan install . --build=missing -s build_type=Debug \
-            --output-folder build/debug
+      - name: Conan install (Debug)
+        uses: ./.github/actions/conan-install
+        with:
+          build-type: Debug
       - name: Configure with clang-tidy
         run: cmake --preset debug -DProjectNestor_ENABLE_CLANG_TIDY=ON
       - name: clang-tidy check
@@ -53,12 +51,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ninja-build
-          pip install conan
-          conan profile detect --force
-      - name: Install Conan dependencies
-        run: |
-          conan install . --build=missing -s build_type=Release \
-            --output-folder build/release
+      - name: Conan install (Release)
+        uses: ./.github/actions/conan-install
+        with:
+          build-type: Release
       - name: Configure
         run: cmake --preset release
       - name: Build
@@ -81,12 +77,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ninja-build
-          pip install conan
-          conan profile detect --force
-      - name: Install Conan dependencies
-        run: |
-          conan install . --build=missing -s build_type=Release \
-            --output-folder build/release
+      - name: Conan install (Release)
+        uses: ./.github/actions/conan-install
+        with:
+          build-type: Release
       - name: Configure
         run: cmake --preset release
       - name: Build
@@ -165,12 +159,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ninja-build
-          pip install conan
-          conan profile detect --force
-      - name: Install Conan dependencies
-        run: |
-          conan install . --build=missing -s build_type=Release \
-            --output-folder build/release
+      - name: Conan install (Release)
+        uses: ./.github/actions/conan-install
+        with:
+          build-type: Release
       - name: Configure with CMake
         run: cmake --preset release
       - name: Build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,15 +25,10 @@ jobs:
           if [ "${{ matrix.compiler }}" = "clang" ]; then
             sudo apt-get install -y clang
           fi
-          pip install conan
-          conan profile detect --force
-      - name: Install Conan dependencies
-        env:
-          BUILD_TYPE: ${{ matrix.build_type }}
-        run: |
-          BUILD_TYPE_CAP=$(echo "$BUILD_TYPE" | sed 's/./\u&/')
-          conan install . --build=missing -s build_type="$BUILD_TYPE_CAP" \
-            --output-folder "build/$BUILD_TYPE"
+      - name: Conan install
+        uses: ./.github/actions/conan-install
+        with:
+          build-type: ${{ matrix.build_type == 'debug' && 'Debug' || 'Release' }}
       - name: Configure
         env:
           COMPILER: ${{ matrix.compiler }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -23,14 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: |
-          sudo apt-get install -y ninja-build clang clang-tidy
-          pip install conan
-          conan profile detect --force
-      - name: Install Conan dependencies
-        run: |
-          conan install . --build=missing -s build_type=Debug \
-            --output-folder build/debug
+        run: sudo apt-get install -y ninja-build clang clang-tidy
+      - name: Conan install (Debug)
+        uses: ./.github/actions/conan-install
+        with:
+          build-type: Debug
       - name: Configure
         run: cmake --preset debug -DProjectNestor_ENABLE_CLANG_TIDY=ON
       - name: Build


### PR DESCRIPTION
## Summary

- Creates `.github/actions/conan-install/action.yml` — a composite action that encapsulates `pip install conan`, `conan profile detect --force`, and `conan install . --build=missing` in one reusable step
- Replaces the copy-pasted conan setup sequence in `_required.yml` (4 jobs: lint, unit-tests, integration-tests, build), `build-test.yml`, and `static-analysis.yml` (clang-tidy job) with a single `uses: ./.github/actions/conan-install` call

## Changes

- `.github/actions/conan-install/action.yml`: new composite action accepting a `build-type` input (`Debug` or `Release`)
- `.github/workflows/_required.yml`: 4 jobs migrated to composite action
- `.github/workflows/build-test.yml`: matrix job migrated to composite action
- `.github/workflows/static-analysis.yml`: clang-tidy job migrated to composite action

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)