### PR TITLE
chore: easy-issue sweep — refs #57 #61 #62 #63

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,45 @@
+# EditorConfig — https://editorconfig.org
+# Top-level config; do not search above this directory.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+# C/C++ sources — match .clang-format (4-space indent already default above)
+[*.{c,h,cc,cpp,hh,hpp,cxx,hxx,inl}]
+indent_style = space
+indent_size = 4
+
+# CMake
+[{CMakeLists.txt,*.cmake}]
+indent_style = space
+indent_size = 2
+
+# YAML / JSON
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+# Markdown — preserve trailing whitespace (used for hard line breaks)
+[*.md]
+trim_trailing_whitespace = false
+indent_size = 2
+
+# Makefiles require tabs
+[{Makefile,makefile,*.mk}]
+indent_style = tab
+
+# Shell scripts
+[*.sh]
+indent_style = space
+indent_size = 2
+
+# justfile
+[{justfile,Justfile}]
+indent_style = space
+indent_size = 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     python3 \
     python3-pip \
+    python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --break-system-packages conan && conan profile detect
+# Install Conan inside an isolated venv to avoid PEP 668 / system-package
+# conflicts (no --break-system-packages). Symlink the entrypoint onto PATH.
+RUN python3 -m venv /opt/conan-venv \
+    && /opt/conan-venv/bin/pip install --no-cache-dir conan \
+    && ln -s /opt/conan-venv/bin/conan /usr/local/bin/conan \
+    && conan profile detect
 
 WORKDIR /src
 

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ format:
 format-check:
   ./scripts/format.sh --check
 
-coverage:
+coverage: deps
   cmake --preset coverage && cmake --build --preset coverage && ./scripts/coverage.sh
 
 clean:


### PR DESCRIPTION
Sweep of mechanical `severity:minor` audit findings. Net: 4 files, +53/-2.

## Issues addressed
- **Refs #62** — Add top-level `.editorconfig` so non-C++ files (YAML/JSON 2-space, Markdown, Make tabs, shell, justfile) have consistent indentation/EOL/charset across editors. C++ rules mirror `.clang-format` (4-space).
- **Refs #63** — `just coverage` now depends on `deps`, matching `build: deps`. Fresh clones can `just coverage` without manually running `just deps` first.
- **Refs #57** — Remove empty `.claude/agents/.gitkeep` directory. No consumers exist; speculative structure can be recreated when a real agent definition lands.
- **Refs #61** — Dockerfile installs Conan into an isolated `/opt/conan-venv` and symlinks `conan` onto `PATH`. Removes `pip install --break-system-packages`, restoring PEP 668 hygiene on Ubuntu 24.04. Adds `python3-venv` to apt deps.

## Deferred
- **#58** (MCP server configuration): no current consumer in Nestor. YAGNI — will revisit when an agent flow actually requires MCP. Commenting on the issue separately.

## Test plan
- [ ] CI green (build-test, static-analysis, code-coverage workflows)
- [ ] `just coverage` works on a fresh clone with no prior `just deps`
- [ ] `docker build .` succeeds; `conan` resolvable on PATH inside builder stage