### PR TITLE
chore: remove silent-failure workarounds and add forbid-suppressions guard

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -93,7 +93,14 @@ jobs:
           else
             mapfile -t cpp_files < <(find src -name "*.cpp" | head -5)
             if [ "${#cpp_files[@]}" -gt 0 ]; then
-              clang-tidy -p build/debug "${cpp_files[@]}"
+              # build/debug/compile_commands.json comes from the GCC build and
+              # contains GCC-only warning flags (-Wduplicated-branches,
+              # -Wduplicated-cond, -Wlogical-op, -Wuseless-cast). Tell clang to
+              # treat unknown warning options as warnings, not as
+              # clang-diagnostic-unknown-warning-option errors.
+              clang-tidy -p build/debug \
+                --extra-arg-before=-Wno-unknown-warning-option \
+                "${cpp_files[@]}"
             else
               echo "::notice::no src/*.cpp files found to clang-tidy"
             fi

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -11,6 +11,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  forbid-suppressions:
+    name: forbid-suppressions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Reject silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files \
+            -- \
+            '*.sh' '*.bash' '*.yml' '*.yaml' '*.hcl' \
+            'Dockerfile*' '**/Dockerfile*' \
+            'justfile' '**/justfile' 'Justfile' '**/Justfile')
+          declare -a scan_files=()
+          for f in "${files[@]}"; do
+            case "$f" in
+              # Exempt this workflow file (heredoc would otherwise self-match)
+              .github/workflows/_required.yml) continue ;;
+              # Exempt any runbook that documents the rule (if present)
+              docs/runbooks/no-silent-failures.md) continue ;;
+            esac
+            scan_files+=("$f")
+          done
+          if [ "${#scan_files[@]}" -eq 0 ]; then
+            echo "No files to scan"
+            exit 0
+          fi
+          if grep -nE '\|\|[[:space:]]*true([[:space:]]*$|[[:space:]]+#)' "${scan_files[@]}"; then
+            echo ""
+            echo '::error::Found silent-failure workarounds above. Refactor per HomericIntelligence/Odysseus#280.'
+            exit 1
+          fi
+          echo 'OK: no silent-failure workarounds found'
+
+      - name: "Reject continue-on-error workflow opt-out"
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No workflow files"
+            exit 0
+          fi
+          if grep -nE '^[[:space:]]*continue-on-error:[[:space:]]*true[[:space:]]*$' "${files[@]}"; then
+            echo ""
+            echo '::error::Found "continue-on-error: true" above. Fix the root cause per HomericIntelligence/Odysseus#280.'
+            exit 1
+          fi
+          echo 'OK: no "continue-on-error: true" found'
+
   lint:
     name: lint
     runs-on: ubuntu-24.04
@@ -36,10 +87,16 @@ jobs:
         run: cmake --preset debug -DProjectNestor_ENABLE_CLANG_TIDY=ON
       - name: clang-tidy check
         run: |
+          set -euo pipefail
           if pixi run clang-tidy 2>/dev/null; then
             echo "pixi clang-tidy passed"
           else
-            find src -name "*.cpp" | head -5 | xargs clang-tidy -- || true
+            mapfile -t cpp_files < <(find src -name "*.cpp" | head -5)
+            if [ "${#cpp_files[@]}" -gt 0 ]; then
+              clang-tidy -p build/debug "${cpp_files[@]}"
+            else
+              echo "::notice::no src/*.cpp files found to clang-tidy"
+            fi
           fi
 
   unit-tests:
@@ -133,6 +190,7 @@ jobs:
 
       - name: Run Gitleaks
         run: |
+          set -euo pipefail
           if [ -f .gitleaks.toml ]; then
             gitleaks detect --source . --config .gitleaks.toml \
               --report-format sarif --report-path gitleaks.sarif --exit-code 0
@@ -140,7 +198,6 @@ jobs:
             gitleaks detect --source . \
               --report-format sarif --report-path gitleaks.sarif --exit-code 0
           fi
-        continue-on-error: true
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
@@ -175,12 +232,21 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate workflow schemas
         run: |
+          set -euo pipefail
           pip install check-jsonschema
-          find .github/workflows -name "*.yml" | \
-            xargs check-jsonschema \
-              --schemafile https://json.schemastore.org/github-workflow || \
-            echo "::warning::Schema validation failed (schemastore.org may be unavailable)"
-        continue-on-error: true
+          schema_url='https://json.schemastore.org/github-workflow'
+          # Probe schemastore once; emit a warning and skip validation only when
+          # the schema is genuinely unreachable. Any other failure must surface.
+          if ! curl -fsSL --max-time 15 -o /tmp/github-workflow.schema.json "$schema_url"; then
+            echo "::warning::schemastore.org unreachable; skipping workflow schema validation"
+            exit 0
+          fi
+          mapfile -t wf_files < <(find .github/workflows -name "*.yml")
+          if [ "${#wf_files[@]}" -eq 0 ]; then
+            echo "No workflow files to validate"
+            exit 0
+          fi
+          check-jsonschema --schemafile /tmp/github-workflow.schema.json "${wf_files[@]}"
 
   deps-version-sync:
     name: deps/version-sync

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,28 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
+
+  - repo: local
+    hooks:
+      - id: forbid-or-true
+        name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
+        description: >
+          Rejects the `or-true` idiom (and its whitespace variants) in shell,
+          YAML, Dockerfile, justfile, and HCL sources. Refactor to an explicit
+          `if`-guard, a real conditional, or a documented `set +e`/`set -e`
+          bracket. See HomericIntelligence/Odysseus#280.
+        language: pygrep
+        entry: '\|\|\s*true(\s*$|\s+#)'
+        files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
+        types: [text]
+        pass_filenames: true
+
+      - id: forbid-continue-on-error
+        name: "forbid continue-on-error workflow opt-out"
+        description: >
+          GitHub Actions `continue-on-error: true` (truthy form) hides real CI
+          failures. Fix the underlying job/step instead.
+        language: pygrep
+        entry: '^\s*continue-on-error:\s*true\s*$'
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: true

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-cmake --preset debug -DProjectNestor_ENABLE_CLANG_TIDY=OFF >/dev/null 2>&1 || true
+if [ ! -f "${ROOT_DIR}/build/debug/compile_commands.json" ]; then
+  cmake --preset debug -DProjectNestor_ENABLE_CLANG_TIDY=OFF >/dev/null
+fi
 find "${ROOT_DIR}/include" "${ROOT_DIR}/src" "${ROOT_DIR}/test" \
   -name "*.cpp" -o -name "*.hpp" | \
   xargs clang-tidy -p "${ROOT_DIR}/build/debug" --config-file="${ROOT_DIR}/.clang-tidy" "$@"


### PR DESCRIPTION
## Summary

Ports the regression guard from HomericIntelligence/Odysseus#280 and refactors every silent-failure workaround in ProjectNestor.

This repo had **2** `|| true` occurrences (matching the brief's grep) and **2** `continue-on-error: true` opt-outs in `.github/workflows/_required.yml`. All four are refactored to fail loudly on real errors, and the `forbid-suppressions` CI job + two pygrep pre-commit hooks are added to prevent regression.

## Refactor table

| Location | Bucket | Before → After |
| --- | --- | --- |
| `scripts/lint.sh:5` | A | `cmake --preset debug ... \|\| true` → existence guard on `build/debug/compile_commands.json`; cmake configure now fails loudly when it actually runs |
| `.github/workflows/_required.yml:42` | A | `find src -name "*.cpp" \| head -5 \| xargs clang-tidy -- \|\| true` → `mapfile` of files, explicit empty-list guard, `clang-tidy -p build/debug` propagates non-zero |
| `.github/workflows/_required.yml:143` | E | Drop `continue-on-error: true` on Gitleaks; step already uses `--exit-code 0` so the opt-out only masked future regressions |
| `.github/workflows/_required.yml:183` | E | Drop `continue-on-error: true` on schema-validation; probe schemastore.org with `curl` once, skip with `::warning::` only on genuine network unavailability, otherwise fail on real schema violations |

## Lint guard

- `.pre-commit-config.yaml`: adds `forbid-or-true` and `forbid-continue-on-error` local pygrep hooks (preserves existing trailing-whitespace / clang-format / conventional-commit hooks).
- `.github/workflows/_required.yml`: adds `forbid-suppressions` job (alongside `lint`, `unit-tests`, etc.) that scans tracked files with `git ls-files` and fails CI with an actionable `::error::` pointing to Odysseus#280.

## Verification

- `pre-commit run --all-files` — **all 9 hooks pass** (incl. the two new ones).
- `bash -n scripts/lint.sh` — clean.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/_required.yml'))"` — parses cleanly.
- `python3 -c "import yaml; yaml.safe_load(open('.pre-commit-config.yaml'))"` — parses cleanly.
- Final grep sweep for both patterns (excluding the workflow's own heredoc): **0 matches**.
- `shellcheck` not available in local pixi env; `bash -n` syntax check used as fallback.

## Test plan

- [ ] CI runs the new `forbid-suppressions` job and stays green.
- [ ] `lint` job still completes the clang-tidy step (now strictly).
- [ ] `security/secrets-scan` Gitleaks step still uploads SARIF on green builds.
- [ ] `schema-validation` warns and skips cleanly if schemastore is unreachable; fails on real schema violations.

## Pre-existing issues observed (out of scope)

None. The working tree was clean on `main` before branching, and no unrelated diffs are included.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>