### PR TITLE
chore: easy-issue sweep 2026-05-11

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -30,9 +30,19 @@ jobs:
       - name: Generate coverage report
         run: ./scripts/coverage.sh
       - name: Check threshold
+        # gcovr has a first-class --fail-under-line flag; the previous
+        # grep + python pipeline broke whenever gcovr changed its summary
+        # wording or when the regex tripped over locale-formatted floats.
         run: |
-          LINE_COV=$(gcovr --root . --filter include --filter src --exclude src/server_main.cpp --exclude src/nats_client.cpp --print-summary build/coverage 2>/dev/null | grep "lines:" | grep -oP '\d+\.\d+' | head -1)
-          python3 -c "import sys; cov=float('${LINE_COV}'); sys.exit(0 if cov >= 80 else 1)"
+          set -euo pipefail
+          gcovr \
+            --root . \
+            --filter include \
+            --filter src \
+            --exclude src/server_main.cpp \
+            --exclude src/nats_client.cpp \
+            --fail-under-line 80 \
+            build/coverage
 
   check-all:
     name: All Coverage Checks

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan to catch newly-published rules even when no PRs land.
+    - cron: "23 5 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL (cpp)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+          pip install conan
+          conan profile detect --force
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: cpp
+          queries: security-and-quality
+      - name: Conan install
+        run: |
+          conan install . --build=missing -s build_type=Debug \
+            --output-folder build/debug
+      - name: Build
+        run: |
+          cmake --preset debug
+          cmake --build --preset debug
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:cpp"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,48 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build and push image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and (conditionally) push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ Nestor transforms raw ideas into researched briefs that Agamemnon can plan and e
 
 ## Building
 
+Conan provides `cpp-httplib`, `nlohmann_json`, and `gtest`. Install
+dependencies first — the CMake presets expect the Conan toolchain at
+`build/debug/`:
+
 ```bash
+just deps          # or: conan install . --output-folder=build/debug \
+                   #         --profile=conan/profiles/debug --build=missing
 cmake --preset debug
 cmake --build --preset debug
 ctest --preset debug

--- a/conan.lock
+++ b/conan.lock
@@ -1,0 +1,11 @@
+{
+    "version": "0.5",
+    "requires": [
+        "nlohmann_json/3.11.3#45828be26eb619a2e04ca517bb7b828d%1701220705.259",
+        "gtest/1.14.0#f8f0757a574a8dd747d16af62d6eb1b7%1743410807.169",
+        "cpp-httplib/0.18.3#ad62795f35f0fecaea1fd4bdb7b949f0%1748426309.372"
+    ],
+    "build_requires": [],
+    "python_requires": [],
+    "config_requires": []
+}

--- a/include/projectnestor/store.hpp
+++ b/include/projectnestor/store.hpp
@@ -9,8 +9,12 @@
 namespace projectnestor {
 using json = nlohmann::json;
 
+namespace detail {
+// Internal helpers — exposed for unit tests only. Not part of the public API
+// and may change without notice. Do NOT call from downstream code.
 std::string generate_uuid();
 std::string now_iso8601();
+}  // namespace detail
 
 class Store {
  public:

--- a/include/projectnestor/store.hpp
+++ b/include/projectnestor/store.hpp
@@ -23,7 +23,10 @@ class Store {
 
  private:
   mutable std::mutex mutex_;
-  std::atomic<int> active_{0};
+  // No "active" counter: the current API has only `submit_research` (→ pending)
+  // and `complete_research` (→ completed) transitions, no claim/start step.
+  // A permanently-zero `active` field misled operators reading /v1/research/stats.
+  // Re-add it once a real "in-progress" state transition exists.
   std::atomic<int> completed_{0};
   std::atomic<int> pending_{0};
   std::unordered_map<std::string, json> research_items_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,0 @@
-#include "projectnestor/version.hpp"
-
-#include <iostream>
-
-int main() {
-  std::cout << projectnestor::kProjectName << " v" << projectnestor::kVersion << "\n";
-  return 0;
-}

--- a/src/nats_client.cpp
+++ b/src/nats_client.cpp
@@ -125,9 +125,11 @@ void NatsClient::publish_log(const std::string& subject, const std::string& leve
   const std::string payload_str = payload.dump();
 
   // Use core NATS publish (non-JetStream) for fire-and-forget log delivery.
-  natsConnection_PublishString(reinterpret_cast<natsConnection*>(conn_), subject.c_str(),
-                               payload_str.c_str());
   // Return value intentionally ignored — log publish failures are non-fatal.
+  // The explicit (void) cast satisfies static analysers (cert-err33-c,
+  // bugprone-unused-return-value) and documents the intent at the call site.
+  (void)natsConnection_PublishString(reinterpret_cast<natsConnection*>(conn_), subject.c_str(),
+                                     payload_str.c_str());
 }
 
 }  // namespace projectnestor

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -34,6 +34,16 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
 
   server.Post("/v1/research",
               [sp, np, extract_topic](const httplib::Request& req, httplib::Response& res) {
+                // Reject anything that doesn't declare a JSON content-type.
+                // Per RFC 9110 §8.3 the media-type may carry parameters
+                // (e.g. "; charset=utf-8"), so match by substring not equality.
+                const std::string ct = req.get_header_value("Content-Type");
+                if (ct.find("application/json") == std::string::npos) {
+                  res.status = 415;
+                  res.set_content(json{{"detail", "Content-Type must be application/json"}}.dump(),
+                                  "application/json");
+                  return;
+                }
                 const auto body = json::parse(req.body, nullptr, false);
                 if (body.is_discarded()) {
                   res.status = 400;

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -10,6 +10,7 @@
 #include <exception>
 #include <iostream>
 #include <string>
+#include <unistd.h>
 
 #include "httplib.h"
 
@@ -17,7 +18,12 @@ namespace {
 httplib::Server* g_server = nullptr;
 
 void signal_handler(int /*signal*/) {
-  std::cout << "\nShutting down ProjectNestor...\n";
+  // Async-signal-safe: write(2) is on the POSIX list; std::cout is NOT.
+  // POSIX.1-2024 §2.4.3 — calling non-async-signal-safe functions from a
+  // signal handler is undefined behaviour.
+  static constexpr char kMsg[] = "\nShutting down ProjectNestor...\n";
+  // Best-effort write; ignore EINTR/short-write — we're tearing down anyway.
+  (void)::write(STDERR_FILENO, kMsg, sizeof(kMsg) - 1);
   if (g_server != nullptr) {
     g_server->stop();
   }

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -7,6 +7,7 @@
 
 #include <csignal>
 #include <cstdlib>
+#include <exception>
 #include <iostream>
 #include <string>
 
@@ -26,8 +27,18 @@ void signal_handler(int /*signal*/) {
 int main() {
   const std::string host = "0.0.0.0";
   const int port = []() -> int {
+    constexpr int kDefaultPort = 8081;
     const char* env = std::getenv("NESTOR_PORT");
-    return env != nullptr ? std::stoi(env) : 8081;
+    if (env == nullptr) {
+      return kDefaultPort;
+    }
+    try {
+      return std::stoi(env);
+    } catch (const std::exception& e) {
+      std::cerr << "[main] Invalid NESTOR_PORT=\"" << env << "\" (" << e.what()
+                << "); falling back to " << kDefaultPort << ".\n";
+      return kDefaultPort;
+    }
   }();
 
   const std::string nats_url = []() -> std::string {

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -52,8 +52,10 @@ std::string now_iso8601() {
 }
 
 json Store::get_stats() const {
+  // "active" is intentionally omitted: there is no claim/start state
+  // transition in the current API, so reporting it as a permanently-zero
+  // value misled operators. Add it back once submit→active→completed exists.
   return json{
-      {"active", active_.load()},
       {"completed", completed_.load()},
       {"pending", pending_.load()},
   };

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -10,6 +10,8 @@
 
 namespace projectnestor {
 
+namespace detail {
+
 std::string generate_uuid() {
   std::random_device rd;
   std::mt19937_64 gen(rd());
@@ -51,6 +53,8 @@ std::string now_iso8601() {
   return oss.str();
 }
 
+}  // namespace detail
+
 json Store::get_stats() const {
   // "active" is intentionally omitted: there is no claim/start state
   // transition in the current API, so reporting it as a permanently-zero
@@ -62,8 +66,8 @@ json Store::get_stats() const {
 }
 
 json Store::submit_research(const json& body) {
-  const std::string id = generate_uuid();
-  const std::string submitted_at = now_iso8601();
+  const std::string id = detail::generate_uuid();
+  const std::string submitted_at = detail::now_iso8601();
 
   const std::string idea = body.value("idea", "");
   const std::string context = body.value("context", "");
@@ -90,7 +94,7 @@ json Store::complete_research(const std::string& id) {
   }
 
   it->second["status"] = "completed";
-  it->second["completed_at"] = now_iso8601();
+  it->second["completed_at"] = detail::now_iso8601();
   --pending_;
   ++completed_;
 

--- a/test/src/test_routes.cpp
+++ b/test/src/test_routes.cpp
@@ -53,7 +53,7 @@ TEST_F(RoutesTest, StatsEndpointReturnsZeros) {
   ASSERT_TRUE(res);
   EXPECT_EQ(res->status, 200);
   const auto body = json::parse(res->body);
-  EXPECT_EQ(body["active"], 0);
+  EXPECT_FALSE(body.contains("active"));
   EXPECT_EQ(body["completed"], 0);
   EXPECT_EQ(body["pending"], 0);
 }

--- a/test/src/test_store.cpp
+++ b/test/src/test_store.cpp
@@ -9,7 +9,7 @@
 namespace projectnestor::test {
 
 TEST(GenerateUuidTest, ReturnsValidV4Format) {
-  const std::string uuid = generate_uuid();
+  const std::string uuid = detail::generate_uuid();
   const std::regex pattern(
       "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-"
       "[0-9a-f]{12}$");
@@ -19,19 +19,19 @@ TEST(GenerateUuidTest, ReturnsValidV4Format) {
 TEST(GenerateUuidTest, GeneratesUniqueValues) {
   std::set<std::string> ids;
   for (int i = 0; i < 100; ++i) {
-    ids.insert(generate_uuid());
+    ids.insert(detail::generate_uuid());
   }
   EXPECT_EQ(ids.size(), 100u);
 }
 
 TEST(NowIso8601Test, ReturnsValidTimestamp) {
-  const std::string ts = now_iso8601();
+  const std::string ts = detail::now_iso8601();
   const std::regex pattern(R"(^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$)");
   EXPECT_TRUE(std::regex_match(ts, pattern)) << "ts=" << ts;
 }
 
 TEST(NowIso8601Test, ReturnsCurrentYear) {
-  const std::string ts = now_iso8601();
+  const std::string ts = detail::now_iso8601();
   const std::string year = ts.substr(0, 4);
   EXPECT_TRUE(year == "2025" || year == "2026" || year == "2027") << "year=" << year;
 }

--- a/test/src/test_store.cpp
+++ b/test/src/test_store.cpp
@@ -39,7 +39,7 @@ TEST(NowIso8601Test, ReturnsCurrentYear) {
 TEST(StoreTest, InitialStatsAreZero) {
   Store store;
   const json stats = store.get_stats();
-  EXPECT_EQ(stats["active"], 0);
+  EXPECT_FALSE(stats.contains("active"));
   EXPECT_EQ(stats["completed"], 0);
   EXPECT_EQ(stats["pending"], 0);
 }
@@ -58,7 +58,7 @@ TEST(StoreTest, SubmitResearchIncrementsPending) {
   store.submit_research({{"idea", "a"}});
   const json stats = store.get_stats();
   EXPECT_EQ(stats["pending"], 1);
-  EXPECT_EQ(stats["active"], 0);
+  EXPECT_FALSE(stats.contains("active"));
   EXPECT_EQ(stats["completed"], 0);
 }
 


### PR DESCRIPTION
## Summary

Bundled implementation of EASY issues from the 2026-05-11 ecosystem-wide sweep across HomericIntelligence/ProjectNestor.

## Implemented (12 issues)

- Closes #13 — `fix(src): remove orphaned main.cpp` — `src/main.cpp` had no executable target; server entry point is `src/server_main.cpp`.
- Closes #16 — `docs(readme): document just deps prerequisite` — README quick-start now mentions `just deps` before `cmake --preset debug`.
- Closes #20 — `refactor(store): move helpers to projectnestor::detail namespace` — `generate_uuid()` / `now_iso8601()` are now under `projectnestor::detail` to signal they are not part of the public API.
- Closes #24 — `fix(server): catch std::stoi exception on invalid NESTOR_PORT` — server falls back to default port instead of crashing on bad env input.
- Closes #25 — `fix(nats): cast natsConnection_PublishString return value to void` — explicit `(void)` cast satisfies cert-err33-c.
- Closes #33 — `ci(docker): add image build/publish workflow targeting GHCR` — new `.github/workflows/docker-publish.yml` builds on PRs and publishes on main + tags.
- Closes #34 — `fix(ci): use gcovr --fail-under-line instead of fragile grep pipeline` — replaces brittle `grep | python3` with native gcovr threshold flag.
- Closes #38 — `build(conan): commit conan.lock for reproducible deps` — locks cpp-httplib, nlohmann_json, gtest at resolved revisions.
- Closes #45 — `ci(security): add CodeQL static-analysis workflow` — new `.github/workflows/codeql.yml` with security-and-quality query suite.
- Closes #50 — `fix(store): drop misleading active counter from /v1/research/stats` — removes permanently-zero `active` field; tests updated.
- Closes #51 — `fix(server): use async-signal-safe write(2) in signal handler` — replaces UB `std::cout` in handler with `::write(STDERR_FILENO, ...)`.
- Closes #66 — `fix(routes): validate Content-Type on POST /v1/research` — non-JSON Content-Type now returns 415.

## ALREADY-DONE (closed via comment, no commit here)

- #35 — `_required.yml` clang-tidy step no longer uses `|| true` (forbid-suppressions guard would now reject any reintroduction).
- #57 — `.claude/agents/` directory does not exist; `.claude/` only contains `settings.json`.
- #61 — Dockerfile installs conan via isolated venv (`/opt/conan-venv`); no `--break-system-packages`.
- #62 — `.editorconfig` is present at repo root and covers C/C++, CMake, YAML/JSON, Markdown, shell, justfile.
- #63 — `justfile` line 30 declares `coverage: deps` — dependency on `just deps` is in place.

## Skipped — exceeds 50-LoC sweep cap or requires design

- #17 — Enable Doxygen API docs (workflow + content generation; medium).
- #21 — Bound `research_items_` (TTL/eviction policy; design decision).
- #28 — Concurrency tests for `Store` (new test scaffolding; medium).
- #29 — Include `nats_client.cpp` in 80% coverage threshold (would lower coverage; needs verification with broker mock).
- #30 — Apply CTest unit/integration labels (requires test categorization across files).
- #39 — Conan profiles for ARM/non-GCC compilers (multi-profile design).
- #46 — Audit logging for security-relevant events (design + downstream consumer changes).
- #55 — Single-source the `0.1.0` version constant across 4 files (release-process work).
- #67 — `POST /complete` completion metadata (Store API + payload schema change).
- #69 — Data retention/deletion policy (design decision; affects API surface).

## Test plan

- [ ] `just deps && cmake --preset debug && cmake --build --preset debug && ctest --preset debug` passes locally.
- [ ] All required CI checks (`unit-tests`, `integration-tests`, `lint`, `build`, `forbid-suppressions`, etc.) pass on this PR.
- [ ] New `Docker Publish` workflow runs the build step (push: false) on this PR.
- [ ] New `CodeQL` workflow completes the analyze step.
- [ ] Coverage workflow's new `--fail-under-line 80` threshold check still passes.