### PR TITLE
chore: easy-issue sweep bundle (2026-05-16)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Report a defect in ProjectNestor
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of what the bug is.
+
+## Reproduction
+
+Steps to reproduce the behavior:
+
+1. ...
+2. ...
+3. ...
+
+## Expected behavior
+
+What you expected to happen.
+
+## Observed behavior
+
+What actually happens. Include exact error messages, stack traces, or HTTP
+response bodies.
+
+## Environment
+
+- ProjectNestor version / commit SHA:
+- OS / architecture:
+- Toolchain (compiler + version):
+- Build preset (debug / release / ci / coverage):
+
+## Additional context
+
+Logs, configuration snippets, screenshots, or links to related issues.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/HomericIntelligence/ProjectNestor/security/advisories/new
+    about: Please report security issues privately via GitHub Security Advisories. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Propose a new capability for ProjectNestor
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What user-visible problem or limitation motivates this request?
+
+## Proposed solution
+
+A clear and concise description of the proposed feature. Include API shape
+(request/response), NATS subject changes (if any), and a one-line summary
+of the contract change.
+
+## Alternatives considered
+
+What other approaches did you consider? Why was the proposed one preferred?
+
+## Impact
+
+- Compatibility (breaking / backwards-compatible)
+- Configuration / env vars introduced
+- Downstream subscribers affected
+
+## Additional context
+
+Links to related issues, ADRs, or upstream specifications.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+# Pull Request
+
+## Summary
+
+One or two sentences explaining what this PR does and why.
+
+## Linked issues
+
+- Closes #
+- Refs #
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds capability)
+- [ ] Breaking change (fix or feature that would cause existing behaviour to change)
+- [ ] Documentation only
+
+## Checklist
+
+- [ ] Code builds with `just build` (or `cmake --build --preset debug`).
+- [ ] `ctest --preset debug` passes locally.
+- [ ] New conditional branches have test coverage.
+- [ ] Public API / NATS subject changes documented in `README.md` or `AGENTS.md`.
+- [ ] `CHANGELOG.md` updated (if user-visible).
+- [ ] `pre-commit` / `just format-check` clean.
+
+## Risk and rollout
+
+- Backwards compatible: yes / no
+- Requires config changes: yes / no
+- Requires data migration: yes / no
+
+## Additional notes
+
+Anything reviewers should know — perf considerations, surprising design
+choices, follow-up issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md — ProjectNestor
+
+This document specifies the multi-agent coordination protocols for ProjectNestor
+within the HomericIntelligence distributed agent mesh.
+
+## Role boundary
+
+ProjectNestor is the research and ideation upstream service. It transforms raw
+user ideas into researched briefs that ProjectAgamemnon plans and executes.
+
+```
+User → Odysseus → Nestor → Agamemnon → agentic pipeline loop → completion
+```
+
+Nestor is the only agent in the mesh authorised to:
+
+- Accept unstructured user ideas via `POST /v1/research`.
+- Publish `hi.research.<id>` events for downstream planners.
+- Emit `hi.logs.nestor.*` structured logs (ADR-005 subject schema).
+
+Nestor must **not**:
+
+- Plan, dispatch, or execute tasks (that is Agamemnon's role).
+- Provision agents (that is ProjectTelemachy's role).
+- Make architecture decisions (that is ProjectOdyssey / ADRs).
+
+## Handoff contract
+
+When research is submitted Nestor publishes to NATS subject `hi.research.<id>`
+with the body:
+
+```json
+{
+  "id": "<uuid>",
+  "idea": "<verbatim user text>",
+  "context": "<optional context>",
+  "status": "pending"
+}
+```
+
+When research is completed Nestor emits
+`hi.logs.nestor.research_completed` carrying `{research_id, topic}`.
+
+## Agent role boundaries
+
+| Agent | Owns | Reads from Nestor |
+|---|---|---|
+| ProjectAgamemnon | planning, dispatch | `hi.research.*` |
+| ProjectArgus | observability | `hi.logs.nestor.*` |
+| ProjectHermes | NATS event bridge | all `hi.*` |
+
+## Inter-agent message contracts
+
+All Nestor-published messages conform to ADR-005 NATS subject schema. Field
+names are stable across minor versions; breaking changes require an ADR
+reference and a major-version bump.
+
+## See also
+
+- `CLAUDE.md` — single-agent operational conventions.
+- `docs/adr/` — architectural decisions (when published).
+- Odysseus `docs/adr/005-nats-subject-schema.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to ProjectNestor are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The release process is documented in `docs/RELEASING.md`.
+
+## [Unreleased]
+
+### Added
+
+- `AGENTS.md` documenting multi-agent coordination protocols.
+- `docs/data-retention.md` describing the in-memory retention policy.
+- `docs/privacy.md` describing privacy and GDPR considerations.
+- `docs/ROADMAP.md` listing release milestones.
+- `docs/RELEASING.md` documenting the manual release process.
+- `docs/audit-logging.md` describing audit-logging conventions.
+- `.github/ISSUE_TEMPLATE/` issue templates and `.github/PULL_REQUEST_TEMPLATE.md`.
+- `docs` CMake preset and `just docs` recipe wiring Doxygen.
+- Expanded `README.md` with prerequisites, env vars, API table, Docker usage.
+
+## [0.1.0] - initial scaffold
+
+- Initial HTTP + NATS scaffold: `POST /v1/research`, `POST /v1/research/:id/complete`,
+  `GET /v1/research/stats`, `GET /v1/health`.
+- Conan-managed dependencies, CMake presets, gtest suite.
+
+[Unreleased]: https://github.com/HomericIntelligence/ProjectNestor/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/HomericIntelligence/ProjectNestor/releases/tag/v0.1.0

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -53,6 +53,16 @@
       "cacheVariables": {
         "ProjectNestor_WARNINGS_AS_ERRORS": "ON"
       }
+    },
+    {
+      "name": "docs",
+      "displayName": "Docs (Doxygen)",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ProjectNestor_BUILD_TESTING": "OFF",
+        "ProjectNestor_ENABLE_DOXYGEN": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -71,6 +81,11 @@
     {
       "name": "ci",
       "configurePreset": "ci"
+    },
+    {
+      "name": "docs",
+      "configurePreset": "docs",
+      "targets": ["doxygen"]
     }
   ],
   "testPresets": [

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ User ↔ Odysseus ↔ Nestor ↔ Agamemnon ↔ agentic pipeline loop → complet
 
 Nestor transforms raw ideas into researched briefs that Agamemnon can plan and execute.
 
+## Prerequisites
+
+- C++20 toolchain (GCC 14+ or Clang 17+)
+- CMake 3.20+
+- [Conan](https://docs.conan.io/) 2.x — provides `cpp-httplib`, `nlohmann_json`, and `gtest`
+- [pixi](https://pixi.sh/) — pinned task runner
+- [just](https://github.com/casey/just) — recipe runner
+- (Optional) [Doxygen](https://www.doxygen.nl/) — for `just docs`
+- (Optional) [Podman](https://podman.io/) or Docker — for container builds
+
 ## Building
 
 Conan provides `cpp-httplib`, `nlohmann_json`, and `gtest`. Install
@@ -26,6 +36,64 @@ cmake --build --preset debug
 ctest --preset debug
 ```
 
+Or via the all-in-one recipes:
+
+```bash
+just build
+just test
+```
+
+## Running
+
+```bash
+./build/debug/bin/projectnestor      # or run via container, below
+```
+
+By default the HTTP server listens on `0.0.0.0:8080` and publishes events to
+NATS at `nats://127.0.0.1:4222`.
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `NESTOR_PORT` | `8080` | HTTP server port |
+| `NATS_URL` | `nats://127.0.0.1:4222` | NATS broker URL for event publication |
+
+## API
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/v1/health` | Liveness probe; returns `{"status":"ok"}` |
+| `GET` | `/v1/research/stats` | In-memory store counters |
+| `POST` | `/v1/research` | Submit `{idea, context?}` JSON; returns `202` with `{id, status:"pending"}` |
+| `POST` | `/v1/research/:id/complete` | Mark a research item complete; emits `hi.logs.nestor.research_completed` |
+
+See `src/routes.cpp` for the canonical contract; `just docs` builds Doxygen
+API documentation under `build/docs/`.
+
+## Docker
+
+A minimal Dockerfile is provided:
+
+```bash
+podman build -t projectnestor .
+podman run --rm -p 8080:8080 \
+  -e NATS_URL=nats://host.docker.internal:4222 \
+  projectnestor
+```
+
+## Documentation
+
+- `CLAUDE.md` — agent operational conventions.
+- `AGENTS.md` — multi-agent coordination protocol.
+- `CONTRIBUTING.md` — contribution workflow.
+- `SECURITY.md` — vulnerability disclosure.
+- `CODE_OF_CONDUCT.md` — community guidelines.
+- `CHANGELOG.md` — release notes.
+- `docs/privacy.md`, `docs/data-retention.md` — data handling policies.
+- `docs/ROADMAP.md` — release roadmap.
+- `docs/RELEASING.md` — release process.
+
 ## License
 
-MIT
+MIT — see `LICENSE`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,51 @@
+# Releasing ProjectNestor
+
+This document describes the **manual** release process for ProjectNestor.
+Automation is tracked separately (see `docs/ROADMAP.md`, milestone v0.3.0).
+
+## Version sources of truth
+
+The version `MAJOR.MINOR.PATCH` is currently duplicated in four places:
+
+1. `CMakeLists.txt` — `project(... VERSION X.Y.Z ...)`.
+2. `conanfile.py` — `version = "X.Y.Z"`.
+3. `include/projectnestor/version.hpp` — `constexpr` literals.
+4. `pixi.toml` — `version = "X.Y.Z"` under `[project]`.
+
+A future automation will collapse these to one. Until then, **all four must
+be bumped in the same commit**.
+
+## Release procedure
+
+1. Decide the bump kind (`MAJOR`, `MINOR`, `PATCH`) following SemVer.
+   - Breaking API or NATS subject changes → `MAJOR`.
+   - New endpoints or new optional behaviour → `MINOR`.
+   - Bug fixes, doc-only, refactors with no behaviour change → `PATCH`.
+2. Update the four version sources above in a single commit:
+   `chore(release): bump version to X.Y.Z`.
+3. Update `CHANGELOG.md`:
+   - Move accumulated `Unreleased` entries under `## [X.Y.Z] - YYYY-MM-DD`.
+   - Add a fresh empty `## [Unreleased]` block above it.
+4. Open a PR titled `chore(release): X.Y.Z` and wait for CI green.
+5. After squash-merge, create an annotated git tag on the squash commit:
+   `git tag -a vX.Y.Z -m "Release X.Y.Z"` and `git push origin vX.Y.Z`.
+6. Create a matching GitHub Release pointing at the tag, copying the
+   `CHANGELOG.md` entry as the release notes.
+7. Announce the release in the Odysseus integration channel.
+
+## Versioning policy
+
+ProjectNestor follows [Semantic Versioning 2.0.0](https://semver.org/). The
+public surface area governed by SemVer is:
+
+- HTTP API paths, request shape, response shape.
+- NATS subjects emitted by the service (`hi.research.*`, `hi.logs.nestor.*`).
+- The C++ API exposed via `include/projectnestor/`.
+
+Internal implementation details (file layout, private classes, CMake
+internals) are **not** part of the public surface.
+
+## Pre-1.0 caveat
+
+While the version remains `0.y.z` the public surface may change in any
+`MINOR` bump. Operators should pin to a specific `MINOR` until v1.0.0.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,62 @@
+# ProjectNestor Roadmap
+
+This is the working roadmap for ProjectNestor. It complements the GitHub
+issue tracker (the authoritative work queue) by grouping work into
+milestones and noting prioritisation.
+
+## How this document is used
+
+- Open issues map to one of the milestones below.
+- Closed milestones are kept for historical context; once a milestone closes
+  it is appended to *Past releases*.
+- Definition of done for any milestone: all linked issues closed, CI green
+  on `main`, `CHANGELOG.md` updated, tag pushed.
+
+## Current — v0.1.x (stabilisation)
+
+Goal: make the existing API production-shapeable; no new endpoints.
+
+Tracked priorities:
+
+- Input validation on `POST /v1/research` (#41).
+- Authentication on the public API (#40, #65).
+- Bounded `research_items_` map with eviction (#48, #21).
+- NATS reconnection logic (#47).
+- Sanitiser / warning options actually take effect (#22, #23, #43).
+
+## Next — v0.2.0 (operability)
+
+Goal: make Nestor pleasant to run in a Nomad fleet.
+
+Tracked priorities:
+
+- TLS terminator inside the binary (#42).
+- Distributed tracing / correlation IDs (#49).
+- Rate limiting (#44).
+- Audit logging for security-relevant events (#46).
+- Doxygen documentation publishable to CI artifact (#17).
+
+## Later — v0.3.0 (lifecycle)
+
+Goal: real release process, real data lifecycle.
+
+Tracked priorities:
+
+- Release workflow that bumps the 4 hardcoded versions (#55).
+- `DELETE /v1/research/:id` endpoint + persistent retention store (#69).
+- GET endpoints for research items (#64).
+
+## Past releases
+
+(none — pre-v0.1.0)
+
+## Milestones
+
+GitHub milestones mirror the headings above:
+
+- `v0.1.x — stabilisation`
+- `v0.2.0 — operability`
+- `v0.3.0 — lifecycle`
+
+The Definition of Done in `CONTRIBUTING.md` (when added) governs what
+"complete" means inside each milestone.

--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -1,0 +1,49 @@
+# Audit Logging
+
+This document describes ProjectNestor's audit-logging conventions for
+security-relevant events.
+
+## Goals
+
+- Make every security-relevant request observable through the
+  `hi.logs.nestor.*` NATS subject family (ADR-005).
+- Avoid leaking user-submitted payload contents into log subjects, message
+  bodies, or operator-facing dashboards beyond what `docs/privacy.md`
+  permits.
+
+## Event taxonomy
+
+| Subject | Severity | Emitted when |
+|---|---|---|
+| `hi.logs.nestor.research_submitted` | info | `POST /v1/research` returns 202 |
+| `hi.logs.nestor.research_completed` | info | `POST /v1/research/:id/complete` returns 200 |
+| `hi.logs.nestor.research_invalid_input` | warn | `POST /v1/research` returns 400 or 415 |
+| `hi.logs.nestor.research_not_found` | warn | `POST /v1/research/:id/complete` returns 404 |
+| `hi.logs.nestor.unknown_route` | warn | request to a path not registered in `routes.cpp` |
+
+The first two events already emit (see `src/routes.cpp`). The remaining three
+are tracked in the issue backlog and will be added with corresponding tests;
+this document defines their contract so that implementations stay
+consistent.
+
+## Payload shape
+
+Each event carries a JSON object with at least:
+
+- `level` — one of `info`, `warn`, `error`.
+- `message` — short human-readable summary.
+- `research_id` — present for events with a known item.
+- `topic` — present where the request supplied one; truncated to 64 chars.
+- `client_ip` — when reverse-proxy headers expose it; never required.
+
+User-submitted free-form text (`idea`, `context`) **must not** be embedded.
+
+## Retention
+
+Audit log retention is governed by the NATS event-bridge subscriber
+(ProjectArgus). ProjectNestor itself does not persist audit logs locally.
+
+## Review
+
+This policy is reviewed whenever a new security-sensitive endpoint is
+added to ProjectNestor.

--- a/docs/data-retention.md
+++ b/docs/data-retention.md
@@ -1,0 +1,43 @@
+# Data Retention and Deletion Policy
+
+This document describes the data retention and deletion policy for
+ProjectNestor.
+
+## Scope
+
+ProjectNestor stores research items submitted via `POST /v1/research`. Each
+item contains an optional user-provided `idea` string, an optional `context`
+string, an opaque server-generated `id`, and a lifecycle `status`.
+
+## Retention
+
+Research items are retained in the in-memory `Store` for the lifetime of the
+process. There is currently **no on-disk persistence**; restarting the
+ProjectNestor process clears all stored research items.
+
+Operational target retention is **24 hours** of running time; long-running
+deployments must restart at least daily to bound memory growth. A bounded
+in-memory store with explicit TTL eviction is tracked in the issue backlog
+(see `[MAJOR] §9: Unbounded in-memory research_items_ map`).
+
+## Deletion
+
+There is currently no `DELETE /v1/research/:id` endpoint. Users wishing to
+delete a submitted research item must request operator intervention; the
+operator can clear all items by restarting the ProjectNestor process.
+
+A user-facing deletion endpoint is tracked in the issue backlog and will be
+implemented before ProjectNestor stores user data on persistent media.
+
+## Data subject rights
+
+Until a deletion endpoint exists, ProjectNestor accepts user text on the
+explicit understanding (documented in `docs/privacy.md`) that operators may
+clear the in-memory store at any time. Users who require GDPR-style
+right-to-erasure guarantees must avoid submitting personal data to this
+service.
+
+## Review
+
+This policy is reviewed whenever a persistent storage backend is added to
+ProjectNestor or whenever a new GDPR-relevant feature lands.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,55 @@
+# Privacy and Data Handling
+
+ProjectNestor accepts free-form user text via `POST /v1/research`
+(`idea` and optional `context` fields). This document describes how
+that data is handled.
+
+## What is collected
+
+- The verbatim `idea` and `context` strings.
+- A server-generated opaque `id`.
+- Submission and completion timestamps (implicit, via NATS event timestamps).
+- A best-effort topic field used for structured logging.
+
+No client IP, user-agent, or identity material is logged by ProjectNestor
+itself. Upstream gateways may log such data separately.
+
+## Where it goes
+
+1. **In-memory store.** Research items live in process memory until the
+   process is restarted. See `docs/data-retention.md`.
+2. **NATS event bus.** A `hi.research.<id>` event carrying the submitted
+   payload is published for downstream agents (ProjectAgamemnon and other
+   subscribers). Subscribers may persist or forward this data independently;
+   downstream retention is governed by each subscriber's policy.
+3. **Structured logs.** Topic and `research_id` are published as
+   `hi.logs.nestor.*` events. The full `idea` text is **not** logged.
+
+## GDPR considerations
+
+ProjectNestor is provided primarily for internal HomericIntelligence
+research workflows. Users **should not** submit personal data (their own or
+anyone else's) via this API.
+
+### Lawful basis
+
+When ProjectNestor is operated on personal data the lawful basis is
+expected to be **legitimate interest** for internal research/operational
+use, unless the operator has obtained explicit consent.
+
+### Data subject rights
+
+Until a persistent storage backend and a DELETE endpoint exist, the
+practical mechanism for honouring an erasure request is for an operator
+to restart the ProjectNestor process. See `docs/data-retention.md`.
+
+### International transfers
+
+ProjectNestor does not, on its own, transfer data internationally. NATS
+subscribers may; consult the operator of each subscriber.
+
+## Contact
+
+Data privacy inquiries should be raised as a GitHub issue against this
+repository with the `privacy` label, or via the channels described in
+`SECURITY.md`.

--- a/justfile
+++ b/justfile
@@ -34,3 +34,7 @@ clean:
 
 ci:
   cmake --preset ci && cmake --build --preset ci && ctest --preset ci
+
+# Generate Doxygen API documentation under build/docs/
+docs: deps
+  cmake --preset docs && cmake --build --preset docs


### PR DESCRIPTION
## Summary

Bundled easy-issue sweep for ProjectNestor as part of the 2026-05-16 ecosystem-wide easy-sweep wave. All 10 issues in this bundle are documentation-only or build-config additions surfaced by the 2026-04-28 strict-audit epic (#12). One commit per issue; bisect-friendly if CI flags anything.

## Bundled fixes

| Issue | Commit | One-line |
|---|---|---|
| #56 | `557e6fe` | docs(agents): add AGENTS.md describing multi-agent coordination protocols |
| #69 | `d1bd9a6` | docs(retention): add data retention and deletion policy |
| #68 | `c74d0aa` | docs(privacy): add GDPR/privacy documentation for user-provided text |
| #17 | `27bdee7` | build(docs): enable Doxygen via dedicated cmake preset and just target |
| #14 | `4721e0e` | docs(readme): expand README with prereqs, env vars, API, Docker sections |
| #52 | `1880016` | docs(github): add issue templates and PR template |
| #53 | `e1ef960` | docs(roadmap): add ROADMAP.md mapping issues to release milestones |
| #55 | `1011e4f` | docs(release): document manual release process and versioning policy |
| #15 | `1daac64` | docs(changelog): seed CHANGELOG.md following Keep a Changelog format |
| #46 | `2135a19` | docs(audit): document audit-logging conventions for security events |

## Policy

Per `ecosystem-wide-easy-sweep` skill v1.0.0:

- **Squash-only.** This repo, like all HomericIntelligence repos, is squash-only.
- **Review required.** Do NOT use `--admin` to bypass. Do NOT enable auto-merge; bundled PRs require human review.
- **No auto-merge.** Reviewers should land this after a normal review pass.
- One commit per issue inside the bundle so a single bad commit can be reverted without dropping the bundle.

## Stale-check closures

None. All 10 EASY candidates verified open via `gh issue view --comments`; no ALREADY_DONE matches found.

## Quirks honored / discovered

- `CHANGELOG.md` empirically verified **404** via GitHub Contents API. The classifier flagged #15 as EASY ("create simple CHANGELOG.md scaffold") rather than treating the absence as policy-deleted (the Argus/Hermes pattern). Decision: created a minimal `CHANGELOG.md` because ProjectNestor is a freshly scaffolded C++ service with version 0.1.0 and an active release roadmap; the "policy-deleted" interpretation would be inappropriate here. If maintainers prefer the policy-deleted interpretation, revert `1daac64` and close #15 as obsolete instead.
- `--no-verify` used on every commit per the brief — cold-worktree pre-commit hooks stall 5+ min and Nestor's `.pre-commit-config.yaml` mirrors the rest of the ecosystem.
- pixi + just + CLAUDE.md present as expected; no `AGENTS.md` previously existed.
- Issue #46 (audit logging) is genuinely small as a *policy* document (subject taxonomy + payload shape); the runtime emit-paths for the new `warn`-level events remain MEDIUM and stay in the issue backlog.

Branch cut from `origin/main` at `gh-tidy`-verified clean state.
