### PR TITLE
fix: bound research_items_ map and erase on complete

### DIFF
--- a/include/projectnestor/store.hpp
+++ b/include/projectnestor/store.hpp
@@ -1,5 +1,6 @@
 #pragma once
-#include <atomic>
+#include <cstddef>
+#include <deque>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -18,6 +19,10 @@ std::string now_iso8601();
 
 class Store {
  public:
+  static constexpr std::size_t kDefaultMaxItems = 10'000;
+
+  explicit Store(std::size_t max_items = kDefaultMaxItems);
+
   json get_stats() const;
   json submit_research(const json& body);
 
@@ -26,13 +31,19 @@ class Store {
   json complete_research(const std::string& id);
 
  private:
+  // Evict the oldest item from the store. Precondition: caller holds mutex_,
+  // insertion_order_ is non-empty, and its front id is present in research_items_.
+  void evict_oldest_locked();
+
   mutable std::mutex mutex_;
   // No "active" counter: the current API has only `submit_research` (→ pending)
   // and `complete_research` (→ completed) transitions, no claim/start step.
   // A permanently-zero `active` field misled operators reading /v1/research/stats.
   // Re-add it once a real "in-progress" state transition exists.
-  std::atomic<int> completed_{0};
-  std::atomic<int> pending_{0};
+  int completed_{0};
+  int pending_{0};
   std::unordered_map<std::string, json> research_items_;
+  std::deque<std::string> insertion_order_;
+  const std::size_t max_items_;
 };
 }  // namespace projectnestor

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -2,6 +2,8 @@
 
 #include "projectnestor/store.hpp"
 
+#include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <ctime>
 #include <iomanip>
@@ -9,6 +11,8 @@
 #include <sstream>
 
 namespace projectnestor {
+
+Store::Store(std::size_t max_items) : max_items_(max_items) {}
 
 namespace detail {
 
@@ -56,12 +60,14 @@ std::string now_iso8601() {
 }  // namespace detail
 
 json Store::get_stats() const {
+  std::lock_guard<std::mutex> lock(mutex_);
   // "active" is intentionally omitted: there is no claim/start state
   // transition in the current API, so reporting it as a permanently-zero
   // value misled operators. Add it back once submit→active→completed exists.
   return json{
-      {"completed", completed_.load()},
-      {"pending", pending_.load()},
+      {"completed", completed_},
+      {"pending", pending_},
+      {"items_count", static_cast<int>(research_items_.size())},
   };
 }
 
@@ -80,8 +86,12 @@ json Store::submit_research(const json& body) {
   {
     std::lock_guard<std::mutex> lock(mutex_);
     research_items_[id] = item;
+    insertion_order_.push_back(id);
+    ++pending_;
+    while (research_items_.size() > max_items_) {
+      evict_oldest_locked();
+    }
   }
-  ++pending_;
 
   return json{{"id", id}, {"status", "pending"}};
 }
@@ -95,10 +105,39 @@ json Store::complete_research(const std::string& id) {
 
   it->second["status"] = "completed";
   it->second["completed_at"] = detail::now_iso8601();
+  json result = it->second;
+
   --pending_;
   ++completed_;
 
-  return it->second;
+  // Erase from map
+  research_items_.erase(it);
+
+  // Erase from insertion order (linear scan, but bounded by max_items_)
+  auto pos = std::find(insertion_order_.begin(), insertion_order_.end(), id);
+  if (pos != insertion_order_.end()) {
+    insertion_order_.erase(pos);
+  }
+
+  return result;
+}
+
+void Store::evict_oldest_locked() {
+  assert(!insertion_order_.empty());
+  const std::string id = std::move(insertion_order_.front());
+  insertion_order_.pop_front();
+
+  auto it = research_items_.find(id);
+  assert(it != research_items_.end());
+
+  const std::string status = it->second.value("status", "");
+  if (status == "pending") {
+    --pending_;
+  } else if (status == "completed") {
+    --completed_;
+  }
+
+  research_items_.erase(it);
 }
 
 }  // namespace projectnestor

--- a/test/src/test_store.cpp
+++ b/test/src/test_store.cpp
@@ -3,6 +3,8 @@
 #include <regex>
 #include <set>
 #include <string>
+#include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -99,6 +101,112 @@ TEST(StoreTest, CompleteResearchUnknownIdReturnsError) {
   Store store;
   const json result = store.complete_research("nonexistent-id");
   EXPECT_EQ(result["error"], "not_found");
+}
+
+TEST(StoreTest, CompleteResearchErasesItem) {
+  Store store;
+  const json submit_result = store.submit_research({{"idea", "test idea"}});
+  const std::string id = submit_result["id"].get<std::string>();
+
+  // First complete should succeed
+  const json completed = store.complete_research(id);
+  EXPECT_EQ(completed["status"], "completed");
+
+  // Second complete on the same id should return not_found (item was erased)
+  const json not_found = store.complete_research(id);
+  EXPECT_EQ(not_found["error"], "not_found");
+}
+
+TEST(StoreTest, EvictsOldestWhenCapExceeded) {
+  Store store(3);
+  std::string oldest_id;
+
+  // Submit 4 items, cap is 3
+  for (int i = 0; i < 4; ++i) {
+    const json result = store.submit_research({{"idea", "idea"}});
+    const std::string id = result["id"].get<std::string>();
+    if (i == 0) {
+      oldest_id = id;
+    }
+  }
+
+  // The oldest item should have been evicted, so complete_research returns not_found
+  const json evicted = store.complete_research(oldest_id);
+  EXPECT_EQ(evicted["error"], "not_found");
+
+  // The other 3 items should still be there
+  const json stats = store.get_stats();
+  EXPECT_EQ(stats["pending"], 3);
+}
+
+TEST(StoreTest, EvictionDecrementsPendingCounter) {
+  Store store(2);
+
+  // Submit 3 pending items, cap is 2
+  store.submit_research({{"idea", "a"}});
+  store.submit_research({{"idea", "b"}});
+  store.submit_research({{"idea", "c"}});
+
+  // The oldest item (a) should have been evicted
+  const json stats = store.get_stats();
+  EXPECT_EQ(stats["pending"], 2);
+}
+
+TEST(StoreTest, EvictionPreservesFifoOrder) {
+  Store store(2);
+
+  const json a_result = store.submit_research({{"idea", "a"}});
+  const std::string a_id = a_result["id"].get<std::string>();
+
+  const json b_result = store.submit_research({{"idea", "b"}});
+  const std::string b_id = b_result["id"].get<std::string>();
+
+  const json c_result = store.submit_research({{"idea", "c"}});
+  // const std::string c_id = c_result["id"].get<std::string>();
+
+  // Only a (oldest) should be evicted
+  EXPECT_EQ(store.complete_research(a_id)["error"], "not_found");
+
+  // b and c should still be completeable
+  const json b_completed = store.complete_research(b_id);
+  EXPECT_EQ(b_completed["status"], "completed");
+
+  const json c_completed = store.complete_research(c_result["id"].get<std::string>());
+  EXPECT_EQ(c_completed["status"], "completed");
+}
+
+TEST(StoreTest, ConcurrentSubmitAndCompleteCounterConsistency) {
+  Store store(1000);
+  const int num_threads = 4;
+  const int ops_per_thread = 250;
+
+  std::vector<std::thread> threads;
+  for (int t = 0; t < num_threads; ++t) {
+    threads.emplace_back([&store, ops_per_thread]() {
+      for (int i = 0; i < ops_per_thread; ++i) {
+        const json submit_result = store.submit_research({{"idea", "test"}});
+        const std::string id = submit_result["id"].get<std::string>();
+        store.complete_research(id);
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  // After all operations, pending should be 0, completed should be total ops
+  const json stats = store.get_stats();
+  EXPECT_EQ(stats["pending"], 0);
+  EXPECT_EQ(stats["completed"], num_threads * ops_per_thread);
+
+  // All items should have been erased
+  // Verify by attempting to complete a few non-existent ids
+  const json check1 = store.complete_research("nonexistent-1");
+  EXPECT_EQ(check1["error"], "not_found");
+
+  const json check2 = store.complete_research("nonexistent-2");
+  EXPECT_EQ(check2["error"], "not_found");
 }
 
 }  // namespace projectnestor::test


### PR DESCRIPTION
## Summary

Fixes #21 — the `research_items_` map was growing without bound. Implements:

- **Erase on complete:** Items are now removed from the map when `complete_research()` is called, fixing the primary bug
- **FIFO cap:** Added configurable max_items cap (default 10,000) with automatic eviction of oldest items when exceeded
- **Counter consistency:** Moved counter operations into the critical section to fix race condition where `++pending_` occurred outside the lock

## Changes

- Replace `std::atomic<int>` counters with plain `int` protected by `mutex_`
- Add `Store` constructor with explicit `max_items` parameter
- Track insertion order with `std::deque<std::string>` for FIFO eviction
- Implement `evict_oldest_locked()` helper to remove oldest item
- Erase items from both `research_items_` and `insertion_order_` on complete
- Add `items_count` field to stats endpoint for observability

## Testing

Added 5 new tests covering:
- Item erasure on complete
- FIFO eviction when cap exceeded
- Counter bookkeeping during eviction
- FIFO ordering preservation
- Concurrent submit/complete stress test

Closes #21