### PR TITLE
fix(conan): make profiles portable across compilers and architectures (#39)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,9 @@ just build
 just test
 ```
 
+Non-Linux contributors (ARM64, macOS): pixi is currently Linux-64 only — install
+Conan, CMake, and Ninja directly and follow `conan/profiles/README.md`.
+
 ### Install Pre-commit Hooks
 
 ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN python3 -m venv /opt/conan-venv \
     && /opt/conan-venv/bin/pip install --no-cache-dir conan \
     && ln -s /opt/conan-venv/bin/conan /usr/local/bin/conan \
-    && conan profile detect
+    && conan profile detect --force
 
 WORKDIR /src
 
@@ -28,7 +28,7 @@ COPY conanfile.py ./
 COPY conan/ conan/
 RUN conan install . \
     --output-folder=build \
-    --profile=conan/profiles/default \
+    --profile:all=conan/profiles/nestor-release \
     --build=missing
 
 # Copy CMake configuration so FetchContent (nats.c) can be cached separately.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Nestor transforms raw ideas into researched briefs that Agamemnon can plan and e
 
 ## Prerequisites
 
-- C++20 toolchain (GCC 14+ or Clang 17+)
+- C++20 toolchain (GCC 12+ or Clang 15+; CI tests against GCC 14 / Clang 17)
 - CMake 3.20+
 - [Conan](https://docs.conan.io/) 2.x — provides `cpp-httplib`, `nlohmann_json`, and `gtest`
 - [pixi](https://pixi.sh/) — pinned task runner
@@ -26,11 +26,14 @@ Nestor transforms raw ideas into researched briefs that Agamemnon can plan and e
 
 Conan provides `cpp-httplib`, `nlohmann_json`, and `gtest`. Install
 dependencies first — the CMake presets expect the Conan toolchain at
-`build/debug/`:
+`build/debug/`.
+
+First-time setup: `conan profile detect --exist-ok` generates your host's base
+profile (the committed profiles extend it via `include(default)`). `just deps`
+runs this automatically.
 
 ```bash
-just deps          # or: conan install . --output-folder=build/debug \
-                   #         --profile=conan/profiles/debug --build=missing
+just deps          # bootstrap + conan install --profile:all=conan/profiles/nestor-debug
 cmake --preset debug
 cmake --build --preset debug
 ctest --preset debug
@@ -42,6 +45,10 @@ Or via the all-in-one recipes:
 just build
 just test
 ```
+
+**Non-Linux hosts (ARM64, macOS):** `pixi` is currently Linux-64 only. Install
+Conan, CMake, and Ninja directly and follow `conan/profiles/README.md` for the
+manual build path.
 
 ## Running
 

--- a/conan/profiles/README.md
+++ b/conan/profiles/README.md
@@ -1,0 +1,62 @@
+# Conan Profiles
+
+ProjectNestor ships two project-level Conan profiles that compose with your
+auto-detected host profile:
+
+- `nestor-debug` — Debug build, C++20
+- `nestor-release` — Release build, C++20
+
+## Why `nestor-*` naming?
+
+Conan 2's `include(name)` resolves the cache profile directory first, then
+falls back to the including file's directory. Naming project profiles `default`
+creates a self-inclusion loop on machines with no cache `default` profile. The
+`nestor-` prefix eliminates this footgun structurally.
+
+## One-time bootstrap
+
+The project profiles use `include(default)` to inherit your host's
+auto-detected settings (OS, arch, compiler, compiler version, libcxx). On a
+fresh machine, generate the cache `default` profile once:
+
+```bash
+conan profile detect --exist-ok
+```
+
+`just deps` and `just deps-release` run this automatically via the
+`_conan-bootstrap` recipe. `--exist-ok` is a no-op if `~/.conan2/profiles/default`
+already exists, preserving any hand-tuned settings.
+
+> **Note:** `--exist-ok` requires Conan >= 2.3 (the minimum pinned in
+> `pixi.toml`). If you installed Conan independently and are on an older
+> version, upgrade or run `conan profile detect --force` manually once.
+
+## Cross-compilation
+
+To build for a different host while keeping native build tools:
+
+```bash
+conan install . \
+  --profile:host=conan/profiles/nestor-release \
+  --profile:build=conan/profiles/nestor-release \
+  --output-folder=build/release \
+  --build=missing
+```
+
+For a fully custom host profile, create one that inherits your target
+platform's base profile and pass it as `--profile:host=`.
+
+## ARM64 / macOS contributors
+
+`pixi.toml` restricts the pixi environment to `linux-64` (toolchain
+availability on conda-forge for macOS/ARM64 is a separate investigation). On
+ARM64 or macOS, install Conan, CMake, and Ninja directly, then:
+
+```bash
+conan profile detect --exist-ok   # generates ~/.conan2/profiles/default
+conan install . --profile:all=conan/profiles/nestor-debug --output-folder=build/debug --build=missing
+cmake --preset debug && cmake --build --preset debug
+```
+
+The project profiles contain no host-specific settings, so they compose
+correctly with whatever `conan profile detect` produces on your platform.

--- a/conan/profiles/debug
+++ b/conan/profiles/debug
@@ -1,8 +1,0 @@
-[settings]
-os=Linux
-compiler=gcc
-compiler.version=14
-compiler.libcxx=libstdc++11
-compiler.cppstd=20
-build_type=Debug
-arch=x86_64

--- a/conan/profiles/default
+++ b/conan/profiles/default
@@ -1,8 +1,0 @@
-[settings]
-os=Linux
-compiler=gcc
-compiler.version=14
-compiler.libcxx=libstdc++11
-compiler.cppstd=20
-build_type=Release
-arch=x86_64

--- a/conan/profiles/nestor-debug
+++ b/conan/profiles/nestor-debug
@@ -1,0 +1,5 @@
+include(default)
+
+[settings]
+compiler.cppstd=20
+build_type=Debug

--- a/conan/profiles/nestor-release
+++ b/conan/profiles/nestor-release
@@ -1,0 +1,5 @@
+include(default)
+
+[settings]
+compiler.cppstd=20
+build_type=Release

--- a/docs/governance/branch-protection.md
+++ b/docs/governance/branch-protection.md
@@ -16,9 +16,10 @@ All PRs to `main` require:
 
 - **Peer review**: Prevents self-merged code from entering the production service
 - **Drift detection**: The `branch-protection-drift` check runs on every PR and ensures the live
-  protection settings on GitHub match the canonical JSON in `.github/branch-protection/main.json`.
-  If anyone modifies the protection rules via the GitHub UI, the next PR will fail the drift check
-  and merge is blocked until the settings are re-applied
+  protection settings on GitHub match the canonical JSON in
+  `.github/branch-protection/main.json`. If anyone modifies the protection rules via the GitHub
+  UI, the next PR will fail the drift check and merge is blocked until the settings are
+  re-applied
 - **Dismiss stale reviews**: Ensures reviewers re-check changes after significant PR updates
 
 ## Configuration
@@ -57,12 +58,13 @@ In rare cases where branch protection must be temporarily modified without commi
    - Who made the change and when
    - Why it was necessary
    - When it will be restored
-3. The PR that merges during the window **must** include a follow-up commit that restores the settings
+3. The PR that merges during the window **must** include a follow-up commit that restores the
+   settings
 4. After the PR merges, immediately run `bash scripts/apply-branch-protection.sh` to restore the
    canonical settings from `.github/branch-protection/main.json`
 
-The `enforce_admins` setting is kept `false` to permit this escape hatch. In normal operation, this
-setting is never used.
+The `enforce_admins` setting is kept `false` to permit this escape hatch. In normal operation,
+this setting is never used.
 
 ## Verifying the Configuration
 

--- a/justfile
+++ b/justfile
@@ -3,13 +3,17 @@ set shell := ["bash", "-c"]
 default:
   @just --list
 
-# Install Conan dependencies (cpp-httplib, nlohmann_json, gtest)
-deps:
-  conan install . --output-folder=build/debug --profile=conan/profiles/debug --build=missing
+# Bootstrap: create ~/.conan2/profiles/default if it does not exist (no-op if present)
+_conan-bootstrap:
+  conan profile detect --exist-ok
+
+# Install Conan dependencies (cpp-httplib, nlohmann_json, gtest) — Debug
+deps: _conan-bootstrap
+  conan install . --output-folder=build/debug --profile:all=conan/profiles/nestor-debug --build=missing
 
 # Install Conan dependencies for release
-deps-release:
-  conan install . --output-folder=build/release --profile=conan/profiles/default --build=missing
+deps-release: _conan-bootstrap
+  conan install . --output-folder=build/release --profile:all=conan/profiles/nestor-release --build=missing
 
 build: deps
   cmake --preset debug && cmake --build --preset debug
@@ -26,7 +30,8 @@ format:
 format-check:
   ./scripts/format.sh --check
 
-coverage: deps
+coverage: _conan-bootstrap
+  conan install . --output-folder=build/coverage --profile:all=conan/profiles/nestor-debug --build=missing && \
   cmake --preset coverage && cmake --build --preset coverage && ./scripts/coverage.sh
 
 clean:
@@ -36,5 +41,6 @@ ci:
   cmake --preset ci && cmake --build --preset ci && ctest --preset ci
 
 # Generate Doxygen API documentation under build/docs/
-docs: deps
+docs: _conan-bootstrap
+  conan install . --output-folder=build/docs --profile:all=conan/profiles/nestor-debug --build=missing && \
   cmake --preset docs && cmake --build --preset docs

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,16 +9,16 @@ platforms = ["linux-64"]
 cmake = ">=3.20"
 ninja = ">=1.11"
 cxx-compiler = ">=1.7"
-conan = ">=2.0"
+conan = ">=2.3"
 openssl = ">=3"
 clang-tools = ">=17"
 gcovr = ">=7"
 pre-commit = ">=3"
 
 [tasks]
-deps = "conan install . --output-folder=build/debug --profile=conan/profiles/debug --build=missing"
+deps = "conan profile detect --exist-ok && conan install . --output-folder=build/debug --profile:all=conan/profiles/nestor-debug --build=missing"
 build = { cmd = "cmake --preset debug && cmake --build --preset debug", depends-on = ["deps"] }
 test = "ctest --preset debug --output-on-failure"
 lint = "./scripts/lint.sh"
 format = "./scripts/format.sh"
-coverage = "conan install . --output-folder=build/coverage --profile=conan/profiles/debug --build=missing && cmake --preset coverage && cmake --build --preset coverage && ./scripts/coverage.sh"
+coverage = "conan profile detect --exist-ok && conan install . --output-folder=build/coverage --profile:all=conan/profiles/nestor-debug --build=missing && cmake --preset coverage && cmake --build --preset coverage && ./scripts/coverage.sh"

--- a/scripts/verify-branch-protection.sh
+++ b/scripts/verify-branch-protection.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify that main branch protection matches the HomericIntelligence ecosystem standard.
+# Verify that main branch protection is correctly configured.
 #
 # This reads the *effective* branch rules via the
 # `GET /repos/{owner}/{repo}/rules/branches/{branch}` endpoint, which is
@@ -8,11 +8,6 @@
 # admin-scoped token the default GITHUB_TOKEN cannot obtain (resulting in a
 # hard 403 "Resource not accessible by integration" on every PR). The rules
 # endpoint exposes the same enforced invariants without needing admin scope.
-#
-# The asserted invariants match the ecosystem standard shared by all
-# HomericIntelligence repos (Agamemnon, Keystone, Hermes, Scylla, Odysseus,
-# Argus, Hephaestus, Myrmidons): PRs required, 0 required approvals,
-# conversation-thread resolution required, required status checks enforced.
 set -euo pipefail
 
 REPO="HomericIntelligence/ProjectNestor"
@@ -35,17 +30,15 @@ if [ -z "$pr_params" ]; then
   exit 1
 fi
 
-# Ecosystem standard: 0 required approvals. Assert the field is present and
-# exactly 0 so drift in either direction (a stray required reviewer, or the
-# rule being dropped) is caught.
-if ! jq -e '.required_approving_review_count == 0' <<<"$pr_params" >/dev/null 2>&1; then
-  echo "ERROR: required_approving_review_count must be 0 (ecosystem standard)"
+# Check required_approving_review_count >= 1
+if ! jq -e '.required_approving_review_count >= 1' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: required_approving_review_count must be >= 1"
   exit 1
 fi
 
-# Ecosystem standard: conversation threads must be resolved before merge.
-if ! jq -e '.required_review_thread_resolution == true' <<<"$pr_params" >/dev/null 2>&1; then
-  echo "ERROR: required_review_thread_resolution must be true"
+# Check stale reviews are dismissed on push.
+if ! jq -e '.dismiss_stale_reviews_on_push == true' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: dismiss_stale_reviews_on_push must be true"
   exit 1
 fi
 

--- a/scripts/verify-branch-protection.sh
+++ b/scripts/verify-branch-protection.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify that main branch protection is correctly configured.
+# Verify that main branch protection matches the HomericIntelligence ecosystem standard.
 #
 # This reads the *effective* branch rules via the
 # `GET /repos/{owner}/{repo}/rules/branches/{branch}` endpoint, which is
@@ -8,6 +8,11 @@
 # admin-scoped token the default GITHUB_TOKEN cannot obtain (resulting in a
 # hard 403 "Resource not accessible by integration" on every PR). The rules
 # endpoint exposes the same enforced invariants without needing admin scope.
+#
+# The asserted invariants match the ecosystem standard shared by all
+# HomericIntelligence repos (Agamemnon, Keystone, Hermes, Scylla, Odysseus,
+# Argus, Hephaestus, Myrmidons): PRs required, 0 required approvals,
+# conversation-thread resolution required, required status checks enforced.
 set -euo pipefail
 
 REPO="HomericIntelligence/ProjectNestor"
@@ -30,15 +35,17 @@ if [ -z "$pr_params" ]; then
   exit 1
 fi
 
-# Check required_approving_review_count >= 1
-if ! jq -e '.required_approving_review_count >= 1' <<<"$pr_params" >/dev/null 2>&1; then
-  echo "ERROR: required_approving_review_count must be >= 1"
+# Ecosystem standard: 0 required approvals. Assert the field is present and
+# exactly 0 so drift in either direction (a stray required reviewer, or the
+# rule being dropped) is caught.
+if ! jq -e '.required_approving_review_count == 0' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: required_approving_review_count must be 0 (ecosystem standard)"
   exit 1
 fi
 
-# Check stale reviews are dismissed on push.
-if ! jq -e '.dismiss_stale_reviews_on_push == true' <<<"$pr_params" >/dev/null 2>&1; then
-  echo "ERROR: dismiss_stale_reviews_on_push must be true"
+# Ecosystem standard: conversation threads must be resolved before merge.
+if ! jq -e '.required_review_thread_resolution == true' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: required_review_thread_resolution must be true"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Rename `conan/profiles/default` + `debug` to `nestor-release` + `nestor-debug` to avoid the Conan 2 self-include infinite-loop footgun when both a project profile and cache profile are named `default`.
- Strip all hardcoded host settings (`os`, `arch`, `compiler`, `compiler.version`, `compiler.libcxx`) from both profiles; retain only `compiler.cppstd=20` and `build_type`. Auto-detection via `include(default)` handles the rest on any platform (GCC 12+, Clang 15+, x86_64, ARM64, macOS).
- Add `_conan-bootstrap` justfile target using `conan profile detect --exist-ok` — a no-op if the cache profile already exists, preserving hand-tuned settings. Requires Conan ≥ 2.3, now pinned in `pixi.toml`.
- Switch every `conan install` call (justfile, pixi.toml, Dockerfile) to `--profile:all=` so both host and build contexts use the composed project profile.
- Fix pre-existing latent bug in `coverage` and `docs` recipes: each now runs its own `conan install` to the preset-named output folder (`build/coverage/`, `build/docs/`) matching the `binaryDir: ${sourceDir}/build/${presetName}` pattern in `CMakePresets.json`.
- Bump `pixi.toml` Conan pin to `>=2.3`; fix `README.md` prerequisite floor to GCC 12+ / Clang 15+; document ARM64/macOS manual path in README, CONTRIBUTING, and new `conan/profiles/README.md`.

## Divergence from plan

- Plan Review approved switching `_conan-bootstrap` to `--exist-ok` since `>=2.3` is already being pinned. Implemented as reviewed (not `--force`), consistent with POLA.
- Dockerfile still uses `conan profile detect --force` (in-Docker bootstrap on a fresh layer; no pre-existing cache to preserve — `--force` is appropriate here).
- `ci` justfile recipe gap (no `deps` dependency) remains out of scope as declared in the plan.
- ARM64/macOS portability is achieved via profile changes; not directly verified on those platforms (noted in plan §6).

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)