### PR TITLE
fix(cmake): gate -Werror behind ProjectNestor_WARNINGS_AS_ERRORS option (#23)

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,9 +1,9 @@
 function(set_project_warnings project_name)
-  set(MSVC_WARNINGS /W4 /WX /permissive-)
+  set(MSVC_WARNINGS /W4 /permissive-)
   set(CLANG_WARNINGS
       -Wall -Wextra -Wpedantic -Wshadow -Wnon-virtual-dtor -Wold-style-cast
       -Wcast-align -Wunused -Woverloaded-virtual -Wconversion -Wsign-conversion
-      -Wnull-dereference -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough -Werror)
+      -Wnull-dereference -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough)
   set(GCC_WARNINGS
       ${CLANG_WARNINGS}
       -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches
@@ -15,6 +15,14 @@ function(set_project_warnings project_name)
     set(PROJECT_WARNINGS_CXX ${CLANG_WARNINGS})
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(PROJECT_WARNINGS_CXX ${GCC_WARNINGS})
+  endif()
+
+  if(ProjectNestor_WARNINGS_AS_ERRORS)
+    if(MSVC)
+      list(APPEND PROJECT_WARNINGS_CXX /WX)
+    else()
+      list(APPEND PROJECT_WARNINGS_CXX -Werror)
+    endif()
   endif()
 
   target_compile_options(${project_name} PRIVATE ${PROJECT_WARNINGS_CXX})

--- a/docs/governance/branch-protection.md
+++ b/docs/governance/branch-protection.md
@@ -16,9 +16,10 @@ All PRs to `main` require:
 
 - **Peer review**: Prevents self-merged code from entering the production service
 - **Drift detection**: The `branch-protection-drift` check runs on every PR and ensures the live
-  protection settings on GitHub match the canonical JSON in `.github/branch-protection/main.json`.
-  If anyone modifies the protection rules via the GitHub UI, the next PR will fail the drift check
-  and merge is blocked until the settings are re-applied
+  protection settings on GitHub match the canonical JSON in
+  `.github/branch-protection/main.json`. If anyone modifies the protection rules via the GitHub
+  UI, the next PR will fail the drift check and merge is blocked until the settings are
+  re-applied
 - **Dismiss stale reviews**: Ensures reviewers re-check changes after significant PR updates
 
 ## Configuration
@@ -57,12 +58,13 @@ In rare cases where branch protection must be temporarily modified without commi
    - Who made the change and when
    - Why it was necessary
    - When it will be restored
-3. The PR that merges during the window **must** include a follow-up commit that restores the settings
+3. The PR that merges during the window **must** include a follow-up commit that restores the
+   settings
 4. After the PR merges, immediately run `bash scripts/apply-branch-protection.sh` to restore the
    canonical settings from `.github/branch-protection/main.json`
 
-The `enforce_admins` setting is kept `false` to permit this escape hatch. In normal operation, this
-setting is never used.
+The `enforce_admins` setting is kept `false` to permit this escape hatch. In normal operation,
+this setting is never used.
 
 ## Verifying the Configuration
 

--- a/scripts/verify-branch-protection.sh
+++ b/scripts/verify-branch-protection.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify that main branch protection matches the HomericIntelligence ecosystem standard.
+# Verify that main branch protection is correctly configured.
 #
 # This reads the *effective* branch rules via the
 # `GET /repos/{owner}/{repo}/rules/branches/{branch}` endpoint, which is
@@ -8,11 +8,6 @@
 # admin-scoped token the default GITHUB_TOKEN cannot obtain (resulting in a
 # hard 403 "Resource not accessible by integration" on every PR). The rules
 # endpoint exposes the same enforced invariants without needing admin scope.
-#
-# The asserted invariants match the ecosystem standard shared by all
-# HomericIntelligence repos (Agamemnon, Keystone, Hermes, Scylla, Odysseus,
-# Argus, Hephaestus, Myrmidons): PRs required, 0 required approvals,
-# conversation-thread resolution required, required status checks enforced.
 set -euo pipefail
 
 REPO="HomericIntelligence/ProjectNestor"
@@ -35,17 +30,15 @@ if [ -z "$pr_params" ]; then
   exit 1
 fi
 
-# Ecosystem standard: 0 required approvals. Assert the field is present and
-# exactly 0 so drift in either direction (a stray required reviewer, or the
-# rule being dropped) is caught.
-if ! jq -e '.required_approving_review_count == 0' <<<"$pr_params" >/dev/null 2>&1; then
-  echo "ERROR: required_approving_review_count must be 0 (ecosystem standard)"
+# Check required_approving_review_count >= 1
+if ! jq -e '.required_approving_review_count >= 1' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: required_approving_review_count must be >= 1"
   exit 1
 fi
 
-# Ecosystem standard: conversation threads must be resolved before merge.
-if ! jq -e '.required_review_thread_resolution == true' <<<"$pr_params" >/dev/null 2>&1; then
-  echo "ERROR: required_review_thread_resolution must be true"
+# Check stale reviews are dismissed on push.
+if ! jq -e '.dismiss_stale_reviews_on_push == true' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: dismiss_stale_reviews_on_push must be true"
   exit 1
 fi
 

--- a/scripts/verify-branch-protection.sh
+++ b/scripts/verify-branch-protection.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify that main branch protection is correctly configured.
+# Verify that main branch protection matches the HomericIntelligence ecosystem standard.
 #
 # This reads the *effective* branch rules via the
 # `GET /repos/{owner}/{repo}/rules/branches/{branch}` endpoint, which is
@@ -8,6 +8,11 @@
 # admin-scoped token the default GITHUB_TOKEN cannot obtain (resulting in a
 # hard 403 "Resource not accessible by integration" on every PR). The rules
 # endpoint exposes the same enforced invariants without needing admin scope.
+#
+# The asserted invariants match the ecosystem standard shared by all
+# HomericIntelligence repos (Agamemnon, Keystone, Hermes, Scylla, Odysseus,
+# Argus, Hephaestus, Myrmidons): PRs required, 0 required approvals,
+# conversation-thread resolution required, required status checks enforced.
 set -euo pipefail
 
 REPO="HomericIntelligence/ProjectNestor"
@@ -30,15 +35,17 @@ if [ -z "$pr_params" ]; then
   exit 1
 fi
 
-# Check required_approving_review_count >= 1
-if ! jq -e '.required_approving_review_count >= 1' <<<"$pr_params" >/dev/null 2>&1; then
-  echo "ERROR: required_approving_review_count must be >= 1"
+# Ecosystem standard: 0 required approvals. Assert the field is present and
+# exactly 0 so drift in either direction (a stray required reviewer, or the
+# rule being dropped) is caught.
+if ! jq -e '.required_approving_review_count == 0' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: required_approving_review_count must be 0 (ecosystem standard)"
   exit 1
 fi
 
-# Check stale reviews are dismissed on push.
-if ! jq -e '.dismiss_stale_reviews_on_push == true' <<<"$pr_params" >/dev/null 2>&1; then
-  echo "ERROR: dismiss_stale_reviews_on_push must be true"
+# Ecosystem standard: conversation threads must be resolved before merge.
+if ! jq -e '.required_review_thread_resolution == true' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: required_review_thread_resolution must be true"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Remove hardcoded `-Werror` from `CLANG_WARNINGS` and `/WX` from `MSVC_WARNINGS` in `cmake/CompilerWarnings.cmake`
- Add a conditional append block after the compiler-specific warning list is selected, guarded by `ProjectNestor_WARNINGS_AS_ERRORS`
- Default behavior preserved: option defaults to `ON` in `cmake/StandardSettings.cmake:5`, so existing builds continue treating warnings as errors; only `-D ProjectNestor_WARNINGS_AS_ERRORS=OFF` now actually disables it

## Divergence from plan

None. The fix matches the plan exactly. CMakePresets.json and StandardSettings.cmake required no changes as confirmed by the plan review.

## Verification

- Positive case (default ON): `-Werror` present in `build/debug/compile_commands.json` via `cmake --preset debug` (option defaults ON)
- Negative case (OFF): `cmake --preset debug -D ProjectNestor_WARNINGS_AS_ERRORS=OFF` produces no `-Werror` in compile_commands.json
- Build: all 7 targets linked cleanly with warnings-as-errors ON
- Tests: 37/37 passed (28 unit + 9 integration)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)