### PR TITLE
test(store): add concurrency tests for Store locking strategy (#28)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -208,6 +208,36 @@ jobs:
             ctest --output-on-failure
           fi
 
+  concurrency-tests:
+    name: concurrency-tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+      - name: Conan install (Release)
+        uses: ./.github/actions/conan-install
+        with:
+          build-type: Release
+      - name: Configure
+        run: cmake --preset release
+      - name: Build
+        run: cmake --build --preset release
+      - name: Run concurrency tests
+        # StoreConcurrencyTest suite validates Store locking under contention.
+        # These tests assert only at quiescence (all threads joined) to tolerate
+        # the known submit_research pending_ asymmetry (see issue #93).
+        # Run 5 consecutive repetitions to surface flaky locking bugs.
+        run: |
+          set -euo pipefail
+          for i in $(seq 5); do
+            echo "--- concurrency run $i/5 ---"
+            cd build/release && ctest --output-on-failure -L concurrency
+            cd ../..
+          done
+
   security-dependency-scan:
     name: security/dependency-scan
     runs-on: ubuntu-24.04

--- a/docs/governance/branch-protection.md
+++ b/docs/governance/branch-protection.md
@@ -16,9 +16,10 @@ All PRs to `main` require:
 
 - **Peer review**: Prevents self-merged code from entering the production service
 - **Drift detection**: The `branch-protection-drift` check runs on every PR and ensures the live
-  protection settings on GitHub match the canonical JSON in `.github/branch-protection/main.json`.
-  If anyone modifies the protection rules via the GitHub UI, the next PR will fail the drift check
-  and merge is blocked until the settings are re-applied
+  protection settings on GitHub match the canonical JSON in
+  `.github/branch-protection/main.json`. If anyone modifies the protection rules via the GitHub
+  UI, the next PR will fail the drift check and merge is blocked until the settings are
+  re-applied
 - **Dismiss stale reviews**: Ensures reviewers re-check changes after significant PR updates
 
 ## Configuration
@@ -57,12 +58,13 @@ In rare cases where branch protection must be temporarily modified without commi
    - Who made the change and when
    - Why it was necessary
    - When it will be restored
-3. The PR that merges during the window **must** include a follow-up commit that restores the settings
+3. The PR that merges during the window **must** include a follow-up commit that restores the
+   settings
 4. After the PR merges, immediately run `bash scripts/apply-branch-protection.sh` to restore the
    canonical settings from `.github/branch-protection/main.json`
 
-The `enforce_admins` setting is kept `false` to permit this escape hatch. In normal operation, this
-setting is never used.
+The `enforce_admins` setting is kept `false` to permit this escape hatch. In normal operation,
+this setting is never used.
 
 ## Verifying the Configuration
 

--- a/scripts/verify-branch-protection.sh
+++ b/scripts/verify-branch-protection.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify that main branch protection matches the HomericIntelligence ecosystem standard.
+# Verify that main branch protection is correctly configured.
 #
 # This reads the *effective* branch rules via the
 # `GET /repos/{owner}/{repo}/rules/branches/{branch}` endpoint, which is
@@ -8,11 +8,6 @@
 # admin-scoped token the default GITHUB_TOKEN cannot obtain (resulting in a
 # hard 403 "Resource not accessible by integration" on every PR). The rules
 # endpoint exposes the same enforced invariants without needing admin scope.
-#
-# The asserted invariants match the ecosystem standard shared by all
-# HomericIntelligence repos (Agamemnon, Keystone, Hermes, Scylla, Odysseus,
-# Argus, Hephaestus, Myrmidons): PRs required, 0 required approvals,
-# conversation-thread resolution required, required status checks enforced.
 set -euo pipefail
 
 REPO="HomericIntelligence/ProjectNestor"
@@ -35,17 +30,15 @@ if [ -z "$pr_params" ]; then
   exit 1
 fi
 
-# Ecosystem standard: 0 required approvals. Assert the field is present and
-# exactly 0 so drift in either direction (a stray required reviewer, or the
-# rule being dropped) is caught.
-if ! jq -e '.required_approving_review_count == 0' <<<"$pr_params" >/dev/null 2>&1; then
-  echo "ERROR: required_approving_review_count must be 0 (ecosystem standard)"
+# Check required_approving_review_count >= 1
+if ! jq -e '.required_approving_review_count >= 1' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: required_approving_review_count must be >= 1"
   exit 1
 fi
 
-# Ecosystem standard: conversation threads must be resolved before merge.
-if ! jq -e '.required_review_thread_resolution == true' <<<"$pr_params" >/dev/null 2>&1; then
-  echo "ERROR: required_review_thread_resolution must be true"
+# Check stale reviews are dismissed on push.
+if ! jq -e '.dismiss_stale_reviews_on_push == true' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: dismiss_stale_reviews_on_push must be true"
   exit 1
 fi
 

--- a/scripts/verify-branch-protection.sh
+++ b/scripts/verify-branch-protection.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify that main branch protection is correctly configured.
+# Verify that main branch protection matches the HomericIntelligence ecosystem standard.
 #
 # This reads the *effective* branch rules via the
 # `GET /repos/{owner}/{repo}/rules/branches/{branch}` endpoint, which is
@@ -8,6 +8,11 @@
 # admin-scoped token the default GITHUB_TOKEN cannot obtain (resulting in a
 # hard 403 "Resource not accessible by integration" on every PR). The rules
 # endpoint exposes the same enforced invariants without needing admin scope.
+#
+# The asserted invariants match the ecosystem standard shared by all
+# HomericIntelligence repos (Agamemnon, Keystone, Hermes, Scylla, Odysseus,
+# Argus, Hephaestus, Myrmidons): PRs required, 0 required approvals,
+# conversation-thread resolution required, required status checks enforced.
 set -euo pipefail
 
 REPO="HomericIntelligence/ProjectNestor"
@@ -30,15 +35,17 @@ if [ -z "$pr_params" ]; then
   exit 1
 fi
 
-# Check required_approving_review_count >= 1
-if ! jq -e '.required_approving_review_count >= 1' <<<"$pr_params" >/dev/null 2>&1; then
-  echo "ERROR: required_approving_review_count must be >= 1"
+# Ecosystem standard: 0 required approvals. Assert the field is present and
+# exactly 0 so drift in either direction (a stray required reviewer, or the
+# rule being dropped) is caught.
+if ! jq -e '.required_approving_review_count == 0' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: required_approving_review_count must be 0 (ecosystem standard)"
   exit 1
 fi
 
-# Check stale reviews are dismissed on push.
-if ! jq -e '.dismiss_stale_reviews_on_push == true' <<<"$pr_params" >/dev/null 2>&1; then
-  echo "ERROR: dismiss_stale_reviews_on_push must be true"
+# Ecosystem standard: conversation threads must be resolved before merge.
+if ! jq -e '.required_review_thread_resolution == true' <<<"$pr_params" >/dev/null 2>&1; then
+  echo "ERROR: required_review_thread_resolution must be true"
   exit 1
 fi
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(GTest REQUIRED)
 add_executable(${PROJECT_NAME}_tests
   src/test_main.cpp
   src/test_store.cpp
+  src/test_store_concurrent.cpp
   src/test_nats_client.cpp
   src/test_routes.cpp
 )
@@ -23,18 +24,27 @@ target_link_libraries(${PROJECT_NAME}_tests
     GTest::gtest_main)
 
 include(GoogleTest)
-# Label tests so the unit/integration split in CI works (#30):
+# Label tests so the unit/integration/concurrency split in CI works:
 #   - Tests in the "Routes" suite exercise the HTTP layer end-to-end and are
 #     labelled "integration".
+#   - Tests in the "StoreConcurrencyTest" suite are labelled "concurrency" and
+#     excluded from the "unit" pass so they do not inflate fast-feedback times.
 #   - All other tests are labelled "unit".
-# Two discovery passes are required because gtest_discover_tests applies one
-# LABELS property per call.
+# Three discovery passes are required because gtest_discover_tests applies one
+# LABELS property per call.  The GTest filter "*-A:B" uses the
+# positive*-negative syntax to exclude both Routes and StoreConcurrencyTest
+# from the unit pass (GTest colon separates negative patterns after the "-").
 gtest_discover_tests(${PROJECT_NAME}_tests
-  TEST_FILTER "-*Routes*"
+  TEST_FILTER "*-*Routes*:*StoreConcurrency*"
   PROPERTIES LABELS "unit"
 )
 gtest_discover_tests(${PROJECT_NAME}_tests
   TEST_FILTER "*Routes*"
   TEST_PREFIX "integration."
   PROPERTIES LABELS "integration"
+)
+gtest_discover_tests(${PROJECT_NAME}_tests
+  TEST_FILTER "*StoreConcurrency*"
+  TEST_PREFIX "concurrency."
+  PROPERTIES LABELS "concurrency"
 )

--- a/test/src/test_store_concurrent.cpp
+++ b/test/src/test_store_concurrent.cpp
@@ -1,0 +1,319 @@
+// test_store_concurrent.cpp — StoreConcurrencyTest suite for projectnestor::Store
+//
+// KNOWN IMPLEMENTATION ASYMMETRY (see issue #93):
+//   submit_research() inserts into research_items_ under mutex_, then releases
+//   the lock, then does ++pending_ (atomic, outside the lock). This means the
+//   map mutation and the pending_ counter are NOT updated atomically together.
+//   A mid-flight get_stats() call may observe a row in the map that is not yet
+//   reflected in pending_.
+//
+//   complete_research() does find + map mutation + --pending_ + ++completed_ ALL
+//   under mutex_, so it is fully consistent internally.
+//
+// DESIGN CONSEQUENCE:
+//   All counter/map assertions in this suite are made AT QUIESCENCE ONLY — after
+//   all test threads have been .join()ed. By the time join() returns, every
+//   ++pending_ atomic increment has retired, so final counter values are exact
+//   regardless of interleaving. No mid-flight invariants on pending_ are asserted.
+//
+// If any test in this suite reveals a counter value inconsistent with the
+// total operation count at quiescence, that is a real bug per the "flag rather
+// than mask" principle (see HomericIntelligence team knowledge base).
+
+#include "projectnestor/store.hpp"
+
+#include <atomic>
+#include <barrier>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace projectnestor::test {
+
+namespace {
+
+// run_parallel — release all `n_threads` threads simultaneously using a
+// std::barrier, then join() every thread before returning.  The caller's
+// `body(thread_index)` lambda is invoked once per thread after the barrier
+// opens.  All assertions on shared state belong AFTER this call returns.
+void run_parallel(int n_threads, std::function<void(int)> body) {
+  std::barrier start_gate(n_threads);
+  std::vector<std::thread> threads;
+  threads.reserve(static_cast<std::size_t>(n_threads));
+
+  for (int t = 0; t < n_threads; ++t) {
+    threads.emplace_back([&start_gate, &body, t]() {
+      start_gate.arrive_and_wait();  // synchronise all threads before work
+      body(t);
+    });
+  }
+
+  for (auto& th : threads) {
+    th.join();
+  }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Test 1: SubmitOnly_ProducesExactPendingCount
+//
+// 8 threads each call submit_research() 1000 times.
+// At quiescence: pending == 8000, completed == 0.
+// ---------------------------------------------------------------------------
+TEST(StoreConcurrencyTest, SubmitOnly_ProducesExactPendingCount) {
+  constexpr int kThreads = 8;
+  constexpr int kItersPerThread = 1000;
+  constexpr int kTotal = kThreads * kItersPerThread;
+
+  Store store;
+
+  run_parallel(kThreads, [&](int /*t*/) {
+    for (int i = 0; i < kItersPerThread; ++i) {
+      store.submit_research({{"idea", "concurrent idea"}, {"context", "ctx"}});
+    }
+  });
+
+  // Quiescent assertions — all ++pending_ atomics have retired by this point.
+  const json stats = store.get_stats();
+  EXPECT_EQ(stats["pending"].get<int>(), kTotal)
+      << "pending counter must equal total submitted at quiescence";
+  EXPECT_EQ(stats["completed"].get<int>(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: CompleteOnly_ProducesExactCompletedCount
+//
+// Pre-submit kTotal items single-threaded to capture IDs.
+// 8 threads each complete their assigned slice of IDs.
+// At quiescence: completed == kTotal, pending == 0.
+// ---------------------------------------------------------------------------
+TEST(StoreConcurrencyTest, CompleteOnly_ProducesExactCompletedCount) {
+  constexpr int kThreads = 8;
+  constexpr int kItersPerThread = 1000;
+  constexpr int kTotal = kThreads * kItersPerThread;
+
+  Store store;
+
+  // Single-threaded setup — no race here.
+  std::vector<std::string> ids;
+  ids.reserve(static_cast<std::size_t>(kTotal));
+  for (int i = 0; i < kTotal; ++i) {
+    const json r = store.submit_research({{"idea", "pre-submitted"}});
+    ids.push_back(r["id"].get<std::string>());
+  }
+
+  ASSERT_EQ(store.get_stats()["pending"].get<int>(), kTotal)
+      << "setup sanity: all submitted before concurrent completion";
+
+  // Each thread completes its own slice — no ID overlap, no contention on
+  // the same item.
+  run_parallel(kThreads, [&](int t) {
+    const int start = t * kItersPerThread;
+    for (int i = start; i < start + kItersPerThread; ++i) {
+      const json result = store.complete_research(ids[static_cast<std::size_t>(i)]);
+      EXPECT_EQ(result["status"].get<std::string>(), "completed")
+          << "each pre-submitted item must complete exactly once";
+    }
+  });
+
+  const json stats = store.get_stats();
+  EXPECT_EQ(stats["completed"].get<int>(), kTotal);
+  EXPECT_EQ(stats["pending"].get<int>(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: MixedSubmitComplete_QuiescentInvariant
+//
+// Producer threads submit; consumer threads complete from a thread-safe queue
+// of IDs.  At quiescence: pending + completed == total_submitted.
+// Tolerates the submit_research asymmetry because all ++pending_ have retired.
+// ---------------------------------------------------------------------------
+TEST(StoreConcurrencyTest, MixedSubmitComplete_QuiescentInvariant) {
+  constexpr int kProducers = 4;
+  constexpr int kConsumers = 4;
+  constexpr int kSubmitsPerProducer = 500;
+  constexpr int kTotal = kProducers * kSubmitsPerProducer;
+
+  Store store;
+
+  // Thread-safe ID queue — producers push, consumers pop.
+  std::mutex queue_mutex;
+  std::vector<std::string> id_queue;
+  id_queue.reserve(static_cast<std::size_t>(kTotal));
+  std::atomic<int> total_submitted{0};
+  std::atomic<bool> producers_done{false};
+
+  // Producer threads
+  std::vector<std::thread> producers;
+  producers.reserve(kProducers);
+  std::barrier producer_gate(kProducers);
+  for (int p = 0; p < kProducers; ++p) {
+    producers.emplace_back([&]() {
+      producer_gate.arrive_and_wait();
+      for (int i = 0; i < kSubmitsPerProducer; ++i) {
+        const json r = store.submit_research({{"idea", "mixed idea"}});
+        const std::string id = r["id"].get<std::string>();
+        {
+          std::lock_guard<std::mutex> lk(queue_mutex);
+          id_queue.push_back(id);
+        }
+        ++total_submitted;
+      }
+    });
+  }
+
+  // Consumer threads
+  std::vector<std::thread> consumers;
+  consumers.reserve(kConsumers);
+  std::barrier consumer_gate(kConsumers);
+  for (int c = 0; c < kConsumers; ++c) {
+    consumers.emplace_back([&]() {
+      consumer_gate.arrive_and_wait();
+      while (true) {
+        std::string id;
+        {
+          std::lock_guard<std::mutex> lk(queue_mutex);
+          if (id_queue.empty()) {
+            if (producers_done.load()) {
+              break;
+            }
+            continue;
+          }
+          id = id_queue.back();
+          id_queue.pop_back();
+        }
+        store.complete_research(id);
+      }
+    });
+  }
+
+  for (auto& t : producers) t.join();
+  producers_done.store(true);
+  for (auto& t : consumers) t.join();
+
+  // Quiescent invariant — pending + completed must equal total submitted.
+  // (pending might be > 0 if some IDs weren't popped before producers_done.)
+  const json stats = store.get_stats();
+  const int final_pending = stats["pending"].get<int>();
+  const int final_completed = stats["completed"].get<int>();
+  const int expected = total_submitted.load();
+
+  EXPECT_EQ(final_pending + final_completed, expected)
+      << "pending=" << final_pending << " completed=" << final_completed
+      << " total_submitted=" << expected;
+  EXPECT_GE(final_completed, 0);
+  EXPECT_GE(final_pending, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: ConcurrentReaders_DoNotCrashOrTearJsonStats
+//
+// Writers submit/complete; readers call get_stats() in a tight loop and verify
+// each snapshot has both keys with integer types and non-negative values.
+// No exact-value assertion mid-flight.  Final state asserted at quiescence.
+// ---------------------------------------------------------------------------
+TEST(StoreConcurrencyTest, ConcurrentReaders_DoNotCrashOrTearJsonStats) {
+  constexpr int kWriters = 4;
+  constexpr int kReaders = 4;
+  constexpr int kOpsPerWriter = 200;
+
+  Store store;
+
+  std::atomic<bool> writers_done{false};
+  std::atomic<int> bad_snapshot_count{0};
+
+  // Reader threads — spin reading stats until writers are done.
+  std::vector<std::thread> readers;
+  readers.reserve(kReaders);
+  std::barrier reader_gate(kReaders);
+  for (int r = 0; r < kReaders; ++r) {
+    readers.emplace_back([&]() {
+      reader_gate.arrive_and_wait();
+      while (!writers_done.load()) {
+        const json stats = store.get_stats();
+        // Validate snapshot structural integrity (mid-flight — no exact values).
+        bool ok = stats.contains("pending") && stats.contains("completed") &&
+                  stats["pending"].is_number_integer() && stats["completed"].is_number_integer() &&
+                  stats["pending"].get<int>() >= 0 && stats["completed"].get<int>() >= 0;
+        if (!ok) {
+          ++bad_snapshot_count;
+        }
+      }
+    });
+  }
+
+  // Writer threads — submit then complete a batch of items.
+  std::barrier writer_gate(kWriters);
+  std::vector<std::thread> writers;
+  writers.reserve(kWriters);
+  for (int w = 0; w < kWriters; ++w) {
+    writers.emplace_back([&]() {
+      writer_gate.arrive_and_wait();
+      for (int i = 0; i < kOpsPerWriter; ++i) {
+        const json r = store.submit_research({{"idea", "reader stress"}});
+        store.complete_research(r["id"].get<std::string>());
+      }
+    });
+  }
+
+  for (auto& t : writers) t.join();
+  writers_done.store(true);
+  for (auto& t : readers) t.join();
+
+  EXPECT_EQ(bad_snapshot_count.load(), 0)
+      << "every get_stats() snapshot must have non-negative integer values for both keys";
+
+  // Final quiescent assertion.
+  const json stats = store.get_stats();
+  EXPECT_EQ(stats["pending"].get<int>(), 0);
+  EXPECT_EQ(stats["completed"].get<int>(), kWriters * kOpsPerWriter);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: DuplicateComplete_AtMostOneSuccess
+//
+// Submit one item. 8 threads each try to complete it 1000 times.
+// At quiescence: completed == 1, and all other calls returned not_found.
+// A failure (completed > 1) surfaces a real locking bug.
+// ---------------------------------------------------------------------------
+TEST(StoreConcurrencyTest, DuplicateComplete_AtMostOneSuccess) {
+  constexpr int kThreads = 8;
+  constexpr int kAttemptsPerThread = 1000;
+
+  Store store;
+
+  const json submit_result = store.submit_research({{"idea", "duplicate test"}});
+  const std::string id = submit_result["id"].get<std::string>();
+
+  std::atomic<int> success_count{0};
+
+  run_parallel(kThreads, [&](int /*t*/) {
+    for (int i = 0; i < kAttemptsPerThread; ++i) {
+      const json result = store.complete_research(id);
+      if (result.contains("status") && result["status"].get<std::string>() == "completed") {
+        ++success_count;
+      } else {
+        // Every non-success must return the canonical not_found error.
+        EXPECT_TRUE(result.contains("error")) << "non-success result must contain 'error' key";
+        EXPECT_EQ(result["error"].get<std::string>(), "not_found")
+            << "non-success result must be 'not_found'";
+      }
+    }
+  });
+
+  // Exactly one completion must have succeeded — the map entry is removed on
+  // first complete, so all subsequent calls hit not_found.
+  EXPECT_EQ(success_count.load(), 1)
+      << "exactly one complete_research() call must succeed for a single item; "
+         "success_count="
+      << success_count.load() << " indicates a real locking bug";
+
+  const json stats = store.get_stats();
+  EXPECT_EQ(stats["completed"].get<int>(), 1);
+  EXPECT_EQ(stats["pending"].get<int>(), 0);
+}
+
+}  // namespace projectnestor::test


### PR DESCRIPTION
## Summary

- Add `StoreConcurrencyTest` suite (`test/src/test_store_concurrent.cpp`) with five deterministic multi-threaded tests for `projectnestor::Store`:
  1. `SubmitOnly_ProducesExactPendingCount` — 8 threads × 1000 submits, verifies `pending == 8000` at quiescence
  2. `CompleteOnly_ProducesExactCompletedCount` — concurrent slice-partitioned completes, verifies `completed == 8000` at quiescence
  3. `MixedSubmitComplete_QuiescentInvariant` — producer/consumer threads, verifies `pending + completed == total_submitted`
  4. `ConcurrentReaders_DoNotCrashOrTearJsonStats` — concurrent readers + writers, verifies snapshot integrity
  5. `DuplicateComplete_AtMostOneSuccess` — 8 threads × 1000 calls on same ID, verifies exactly one succeeds (surfaces real locking bugs)

- All assertions are at quiescence (post-`join()`) to tolerate the verified `pending_` asymmetry in `submit_research()` (map insert under `mutex_`, `++pending_` outside) without masking it. See issue #93 for the follow-up fix.

- Update `test/CMakeLists.txt`: add source, add third `gtest_discover_tests` pass with `TEST_FILTER "*StoreConcurrency*"` / `PROPERTIES LABELS "concurrency"`, correct the unit pass filter to `"*-*Routes*:*StoreConcurrency*"` to exclude both suites from `unit`.

- Add `concurrency-tests` CI job to `.github/workflows/_required.yml` that runs `ctest -L concurrency` 5 consecutive times for flake detection.

- Filed follow-up issue #93: "Store::submit_research increments `pending_` outside `mutex_`".

## Divergence from plan

- GTest filter `"-*Routes*:-*StoreConcurrency*"` proved ineffective at discovery time — the correct syntax is `"*-*Routes*:*StoreConcurrency*"` (verified empirically). Filter comment updated accordingly.
- `ctest --repeat until-fail:N` (from plan §7) is not a valid ctest flag — replaced with a shell `for`/`seq` loop in the CI job.

## Verification

- `ctest --preset debug -L unit -N`: confirms StoreConcurrencyTest absent (28 unit tests, none named StoreConcurrencyTest)
- `ctest --preset debug -L concurrency -N`: lists exactly 5 `concurrency.StoreConcurrencyTest.*` tests
- `ctest --preset debug -L unit --output-on-failure`: 28/28 pass, no regression
- `ctest --preset debug -L concurrency --output-on-failure` × 3 consecutive runs: 5/5 pass each time
- No TSan validation claimed (ENABLE_SANITIZERS not wired — see issue #93)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)