### PR TITLE
fix(docs): SECURITY.md MD030 list-marker spacing

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -115,7 +115,7 @@ When contributing to ProjectNestor:
 
 - Validate all HTTP request input before processing
 - Avoid buffer overflows and undefined behavior
--  Build with `cmake --preset debug` to run under AddressSanitizer + UndefinedBehaviorSanitizer; investigate any reports
+- Build with `cmake --preset debug` to run under AddressSanitizer + UndefinedBehaviorSanitizer; investigate any reports
   before merging.
 - Never commit secrets, API keys, tokens, or credentials
 - Pin FetchContent dependency versions to known-good commits


### PR DESCRIPTION
Collapses a double-space after a list marker on SECURITY.md:118 (MD030). Final remaining markdownlint violation on main after the MD013 rewraps in #104/#105. No content change.