### PR TITLE
fix(ci): fix ASAN gtest discovery + upgrade codeql v3→v4 + pin all actions

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: "Reject silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
         run: |
@@ -98,7 +98,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Verify branch protection configuration
         run: bash scripts/verify-branch-protection.sh
 
@@ -106,7 +106,7 @@ jobs:
     name: lint
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Install clang-format
         # Ensure clang-format is present so the check below cannot silently
         # bypass enforcement when the tool is missing — see #32.
@@ -160,7 +160,7 @@ jobs:
     name: unit-tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -186,7 +186,7 @@ jobs:
     name: integration-tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -212,7 +212,7 @@ jobs:
     name: concurrency-tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -242,9 +242,9 @@ jobs:
     name: security/dependency-scan
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -262,7 +262,7 @@ jobs:
     name: security/secrets-scan
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
       - name: Install Gitleaks
@@ -288,7 +288,7 @@ jobs:
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: gitleaks-report
           path: gitleaks.sarif
@@ -298,7 +298,7 @@ jobs:
     name: build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -316,7 +316,7 @@ jobs:
     name: schema-validation
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Validate workflow schemas
         # Use the network-free vendored schema. The previous schemastore.org
         # fetch was wrapped in an advisory `::warning::` to tolerate outages —
@@ -333,7 +333,7 @@ jobs:
     name: deps/version-sync
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Check CMake version parseable
         run: |
           python3 -c "
@@ -378,7 +378,7 @@ jobs:
           fi
       - name: Setup pixi
         if: steps.detect.outputs.skip == 'false'
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11  # v0.9.6
         with:
           pixi-version: v0.67.2
           cache: false

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
         compiler: [gcc, clang]
         build_type: [debug, release]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -11,7 +11,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Install dependencies
         run: |
           sudo apt-get install -y ninja-build gcovr

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Install build deps
         run: |
           sudo apt-get update
@@ -27,7 +27,7 @@ jobs:
           pip install conan
           conan profile detect --force
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
         with:
           languages: cpp
           queries: security-and-quality
@@ -40,6 +40,6 @@ jobs:
           cmake --preset debug
           cmake --build --preset debug
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
         with:
           category: "/language:cpp"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,7 +11,7 @@ jobs:
     name: clang-format
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Build clang-format container
         run: podman build -t projectnestor-clang-format -f Dockerfile.clang-format .
       - name: Check formatting
@@ -21,7 +21,7 @@ jobs:
     name: clang-tidy
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Install dependencies
         run: sudo apt-get install -y ninja-build clang clang-tidy
       - name: Conan install (Debug)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,15 +48,18 @@ include(GoogleTest)
 # positive*-negative syntax to exclude both Routes and StoreConcurrencyTest
 # from the unit pass (GTest colon separates negative patterns after the "-").
 gtest_discover_tests(${PROJECT_NAME}_tests
+  DISCOVERY_MODE PRE_TEST
   TEST_FILTER "*-*Routes*:*StoreConcurrency*"
   PROPERTIES LABELS "unit"
 )
 gtest_discover_tests(${PROJECT_NAME}_tests
+  DISCOVERY_MODE PRE_TEST
   TEST_FILTER "*Routes*"
   TEST_PREFIX "integration."
   PROPERTIES LABELS "integration"
 )
 gtest_discover_tests(${PROJECT_NAME}_tests
+  DISCOVERY_MODE PRE_TEST
   TEST_FILTER "*StoreConcurrency*"
   TEST_PREFIX "concurrency."
   PROPERTIES LABELS "concurrency"


### PR DESCRIPTION
## Summary
- Fix CodeQL CI failure: add `DISCOVERY_MODE PRE_TEST` to `gtest_discover_tests()` calls to prevent ASAN runtime from being loaded during CMake configure-time test discovery
- Upgrade `github/codeql-action` from v3 to v4 SHA (Node 20 deprecated — forced Node 24 cutoff June 16, 2026)
- Pin all GitHub Actions `uses:` references to latest commit SHAs across all 6 workflow files

## Root Cause
`gtest_discover_tests` without `DISCOVERY_MODE PRE_TEST` runs the test binary at CMake configure time to enumerate tests. With ASAN/UBSAN linked, this fails because ASan runtime is not preloaded in that environment.